### PR TITLE
Reducing CRD sync interval from 15secs to 2 secs

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -55,7 +55,7 @@ var (
 const (
 	// customResourceUpdateRate is the maximum rate in which a custom
 	// resource is updated
-	customResourceUpdateRate = 15 * time.Second
+	customResourceUpdateRate = 2 * time.Second
 
 	fieldName = "name"
 )


### PR DESCRIPTION
Reducing CRD sync interval to reduce the likelihood of hitting a race condition when using AWS release excess IPs feature.