### PR TITLE
Fix for excess IP release race condition | handshake between agent and operator

### DIFF
--- a/operator/flags.go
+++ b/operator/flags.go
@@ -326,7 +326,7 @@ func init() {
 	flags.String(option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
 	option.BindEnv(option.K8sServiceProxyName)
 
-	flags.Int(operatorOption.ExcessIPReleaseDelay, 120, "Number of seconds operator would wait before it releases an IP previously marked as excess. Defaults to 120")
+	flags.Int(operatorOption.ExcessIPReleaseDelay, 180, "Number of seconds operator would wait before it releases an IP previously marked as excess. Defaults to 180")
 	option.BindEnv(operatorOption.ExcessIPReleaseDelay)
 
 	viper.BindPFlags(flags)

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -326,5 +326,8 @@ func init() {
 	flags.String(option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
 	option.BindEnv(option.K8sServiceProxyName)
 
+	flags.Int(operatorOption.ExcessIPReleaseDelay, 120, "Number of seconds operator would wait before it releases an IP previously marked as excess. Defaults to 120")
+	option.BindEnv(operatorOption.ExcessIPReleaseDelay)
+
 	viper.BindPFlags(flags)
 }

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -142,7 +142,7 @@ const (
 	AWSReleaseExcessIPs = "aws-release-excess-ips"
 
 	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
-	// Defaults to 120 secs
+	// Defaults to 180 secs
 	ExcessIPReleaseDelay = "excess-ip-release-delay"
 
 	// ENITags are the tags that will be added to every ENI created by the
@@ -303,7 +303,7 @@ type OperatorConfig struct {
 	AWSReleaseExcessIPs bool
 
 	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
-	// Defaults to 120 secs
+	// Defaults to 180 secs
 	ExcessIPReleaseDelay int
 
 	// UpdateEC2AdapterLimitViaAPI configures the operator to use the EC2 API to fill out the instnacetype to adapter limit mapping

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -141,6 +141,10 @@ const (
 	// the number of API calls to AWS EC2 service.
 	AWSReleaseExcessIPs = "aws-release-excess-ips"
 
+	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
+	// Defaults to 120 secs
+	ExcessIPReleaseDelay = "excess-ip-release-delay"
+
 	// ENITags are the tags that will be added to every ENI created by the
 	// AWS ENI IPAM.
 	ENITags = "eni-tags"
@@ -298,6 +302,10 @@ type OperatorConfig struct {
 	// the number of API calls to AWS EC2 service.
 	AWSReleaseExcessIPs bool
 
+	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
+	// Defaults to 120 secs
+	ExcessIPReleaseDelay int
+
 	// UpdateEC2AdapterLimitViaAPI configures the operator to use the EC2 API to fill out the instnacetype to adapter limit mapping
 	UpdateEC2AdapterLimitViaAPI bool
 
@@ -357,6 +365,7 @@ func (c *OperatorConfig) Populate() {
 	c.LeaderElectionLeaseDuration = viper.GetDuration(LeaderElectionLeaseDuration)
 	c.LeaderElectionRenewDeadline = viper.GetDuration(LeaderElectionRenewDeadline)
 	c.LeaderElectionRetryPeriod = viper.GetDuration(LeaderElectionRetryPeriod)
+	c.ExcessIPReleaseDelay = viper.GetInt(ExcessIPReleaseDelay)
 
 	// AWS options
 

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -18,6 +18,7 @@ package eni
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -118,9 +119,17 @@ func (n *Node) PrepareIPRelease(excessIPs int, scopedLog *logrus.Entry) *ipam.Re
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
+	// Needed for selecting the same ENI to release IPs from
+	// when more than one ENI qualifies for release
+	eniIds := make([]string, 0, len(n.enis))
+	for k := range n.enis {
+		eniIds = append(eniIds, k)
+	}
+	sort.Strings(eniIds)
 	// Iterate over ENIs on this node, select the ENI with the most
 	// addresses available for release
-	for key, e := range n.enis {
+	for _, eniId := range eniIds {
+		e := n.enis[eniId]
 		scopedLog.WithFields(logrus.Fields{
 			fieldEniID:     e.ID,
 			"needIndex":    *n.k8sObj.Spec.ENI.FirstInterfaceIndex,
@@ -159,7 +168,7 @@ func (n *Node) PrepareIPRelease(excessIPs int, scopedLog *logrus.Entry) *ipam.Re
 		eniWithMoreFreeIPsFound := maxReleaseOnENI > len(r.IPsToRelease)
 		// Select the ENI with the most addresses available for release
 		if firstENIWithFreeIPFound || eniWithMoreFreeIPsFound {
-			r.InterfaceID = key
+			r.InterfaceID = eniId
 			r.PoolID = ipamTypes.PoolID(e.Subnet.ID)
 			r.IPsToRelease = freeIpsOnENI[:maxReleaseOnENI]
 		}

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -1,0 +1,82 @@
+package ipam
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/pkg/addressing"
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/datapath/fake"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	"github.com/cilium/cilium/pkg/trigger"
+
+	. "gopkg.in/check.v1"
+)
+
+type testConfigurationCRD struct{}
+
+func (t *testConfigurationCRD) IPv4Enabled() bool                        { return true }
+func (t *testConfigurationCRD) IPv6Enabled() bool                        { return false }
+func (t *testConfigurationCRD) HealthCheckingEnabled() bool              { return true }
+func (t *testConfigurationCRD) IPAMMode() string                         { return ipamOption.IPAMCRD }
+func (t *testConfigurationCRD) BlacklistConflictingRoutesEnabled() bool  { return false }
+func (t *testConfigurationCRD) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}
+func (t *testConfigurationCRD) IPv4NativeRoutingCIDR() *cidr.CIDR        { return nil }
+
+func newFakeNodeStore(conf Configuration, c *C) *nodeStore {
+	t, err := trigger.NewTrigger(trigger.Parameters{
+		Name:        "fake-crd-allocator-node-refresher",
+		MinInterval: 3 * time.Second,
+		TriggerFunc: func(reasons []string) {},
+	})
+	if err != nil {
+		log.WithError(err).Fatal("Unable to initialize CiliumNode synchronization trigger")
+	}
+	store := &nodeStore{
+		allocators:         []*crdAllocator{},
+		allocationPoolSize: map[Family]int{},
+		conf:               conf,
+		refreshTrigger:     t,
+	}
+	return store
+}
+
+func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
+	cn := newCiliumNode("node1", 4, 4, 0)
+	dummyResource := ipamTypes.AllocationIP{Resource: "foo"}
+	for i := 1; i <= 4; i++ {
+		cn.Spec.IPAM.Pool[fmt.Sprintf("1.1.1.%d", i)] = dummyResource
+	}
+	cn.Spec.IPAM.Pool["1.1.1.4"] = dummyResource
+
+	fakeAddressing := fake.NewNodeAddressing()
+	conf := &testConfigurationCRD{}
+	initNodeStore.Do(func() {
+		sharedNodeStore = newFakeNodeStore(conf, c)
+		sharedNodeStore.ownNode = cn
+	})
+	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, &ownerMock{})
+	sharedNodeStore.updateLocalNodeResource(cn)
+
+	// Allocate the first 3 IPs
+	for i := 1; i <= 3; i++ {
+		epipv4, _ := addressing.NewCiliumIPv4(fmt.Sprintf("1.1.1.%d", i))
+		_, err := ipam.IPv4Allocator.Allocate(epipv4.IP(), fmt.Sprintf("test%d", i))
+		c.Assert(err, IsNil)
+	}
+
+	// Verify that the agent marks IP as ready for release and that the IP cannot be allocated meanwhile.
+	cn.Status.IPAM.ReleaseIps["1.1.1.4"] = ipamOption.IPAMMarkForRelease
+	epipv4, _ := addressing.NewCiliumIPv4("1.1.1.4")
+	_, err := ipam.IPv4Allocator.Allocate(epipv4.IP(), "test")
+	c.Assert(err, NotNil)
+	sharedNodeStore.updateLocalNodeResource(cn)
+	c.Assert(int(cn.Status.IPAM.ReleaseIps["1.1.1.4"]), checker.Equals, ipamOption.IPAMReadyForRelease)
+
+	// Verify that 1.1.1.3 is denied for release, since it's already in use
+	cn.Status.IPAM.ReleaseIps["1.1.1.3"] = ipamOption.IPAMMarkForRelease
+	sharedNodeStore.updateLocalNodeResource(cn)
+	c.Assert(int(cn.Status.IPAM.ReleaseIps["1.1.1.3"]), checker.Equals, ipamOption.IPAMDoNotRelease)
+}

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -67,17 +67,17 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 	}
 
 	// Update 1.1.1.4 as marked for release like operator would.
-	cn.Status.IPAM.ReleaseIps["1.1.1.4"] = ipamOption.IPAMMarkForRelease
+	cn.Status.IPAM.ReleaseIPs["1.1.1.4"] = ipamOption.IPAMMarkForRelease
 	// Attempts to allocate 1.1.1.4 should fail, since it's already marked for release
 	epipv4, _ := addressing.NewCiliumIPv4("1.1.1.4")
 	_, err := ipam.IPv4Allocator.Allocate(epipv4.IP(), "test")
 	c.Assert(err, NotNil)
 	// Call agent's CRD update function. status for 1.1.1.4 should change from marked for release to ready for release
 	sharedNodeStore.updateLocalNodeResource(cn)
-	c.Assert(cn.Status.IPAM.ReleaseIps["1.1.1.4"], checker.Equals, ipamOption.IPAMReadyForRelease)
+	c.Assert(cn.Status.IPAM.ReleaseIPs["1.1.1.4"], checker.Equals, ipamOption.IPAMReadyForRelease)
 
 	// Verify that 1.1.1.3 is denied for release, since it's already in use
-	cn.Status.IPAM.ReleaseIps["1.1.1.3"] = ipamOption.IPAMMarkForRelease
+	cn.Status.IPAM.ReleaseIPs["1.1.1.3"] = ipamOption.IPAMMarkForRelease
 	sharedNodeStore.updateLocalNodeResource(cn)
-	c.Assert(cn.Status.IPAM.ReleaseIps["1.1.1.3"], checker.Equals, ipamOption.IPAMDoNotRelease)
+	c.Assert(cn.Status.IPAM.ReleaseIPs["1.1.1.3"], checker.Equals, ipamOption.IPAMDoNotRelease)
 }

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -49,7 +49,6 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 	for i := 1; i <= 4; i++ {
 		cn.Spec.IPAM.Pool[fmt.Sprintf("1.1.1.%d", i)] = dummyResource
 	}
-	cn.Spec.IPAM.Pool["1.1.1.4"] = dummyResource
 
 	fakeAddressing := fake.NewNodeAddressing()
 	conf := &testConfigurationCRD{}

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -268,7 +268,7 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 			name:                resource.Name,
 			manager:             n,
 			ipsMarkedForRelease: make(map[string]time.Time),
-			ipReleaseStatus:     make(map[string]uint8),
+			ipReleaseStatus:     make(map[string]string),
 		}
 
 		node.ops = n.instancesAPI.CreateNode(resource, node)

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -265,8 +265,10 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 	}()
 	if !ok {
 		node = &Node{
-			name:    resource.Name,
-			manager: n,
+			name:                resource.Name,
+			manager:             n,
+			ipsMarkedForRelease: make(map[string]time.Time),
+			ipReleaseStatus:     make(map[string]uint8),
 		}
 
 		node.ops = n.instancesAPI.CreateNode(resource, node)
@@ -314,7 +316,6 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 		node.poolMaintainer = poolMaintainer
 		node.k8sSync = k8sSync
 		n.nodes[node.name] = node
-
 		log.WithField(fieldName, resource.Name).Info("Discovered new CiliumNode custom resource")
 	}
 

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -239,7 +239,7 @@ func newCiliumNode(node string, preAllocate, minAllocate, used int) *v2.CiliumNo
 		Status: v2.NodeStatus{
 			IPAM: ipamTypes.IPAMStatus{
 				Used:       ipamTypes.AllocationMap{},
-				ReleaseIps: map[string]string{},
+				ReleaseIPs: map[string]string{},
 			},
 		},
 	}
@@ -392,9 +392,9 @@ func (e *IPAMSuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 }
 
 func FakeAcknowledgeReleaseIps(cn *v2.CiliumNode) {
-	for ip, status := range cn.Status.IPAM.ReleaseIps {
+	for ip, status := range cn.Status.IPAM.ReleaseIPs {
 		if status == ipamOption.IPAMMarkForRelease {
-			cn.Status.IPAM.ReleaseIps[ip] = ipamOption.IPAMReadyForRelease
+			cn.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMReadyForRelease
 		}
 	}
 }

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -239,7 +239,7 @@ func newCiliumNode(node string, preAllocate, minAllocate, used int) *v2.CiliumNo
 		Status: v2.NodeStatus{
 			IPAM: ipamTypes.IPAMStatus{
 				Used:       ipamTypes.AllocationMap{},
-				ReleaseIps: map[string]uint8{},
+				ReleaseIps: map[string]string{},
 			},
 		},
 	}

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -40,7 +40,7 @@ const (
 )
 
 const (
-	IPAMMarkForRelease = iota
-	IPAMReadyForRelease
-	IPAMDoNotRelease
+	IPAMMarkForRelease  = "marked-for-release"
+	IPAMReadyForRelease = "ready-for-release"
+	IPAMDoNotRelease    = "do-not-release"
 )

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -38,3 +38,9 @@ const (
 	// option.IPAM
 	IPAMClusterPool = "cluster-pool"
 )
+
+const (
+	IPAMMarkForRelease = iota
+	IPAMReadyForRelease
+	IPAMDoNotRelease
+)

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -125,6 +125,14 @@ type IPAMStatus struct {
 	//
 	// +optional
 	OperatorStatus OperatorStatus `json:"operator-status,omitempty"`
+
+	// ReleaseIps tracks the state for every IP considered for release.
+	// 0 - IPAMMarkForRelease : Marked for Release
+	// 1 - IPAMReadyForRelease : Acknowledged as safe to release by agent
+	// 2 - IPAMDoNotRelease : Release request denied by agent
+	//
+	// +optional
+	ReleaseIps map[string]uint8 `json:"release-ips,omitempty"`
 }
 
 // OperatorStatus is the status used by cilium-operator to report

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -127,12 +127,13 @@ type IPAMStatus struct {
 	OperatorStatus OperatorStatus `json:"operator-status,omitempty"`
 
 	// ReleaseIps tracks the state for every IP considered for release.
-	// 0 - IPAMMarkForRelease : Marked for Release
-	// 1 - IPAMReadyForRelease : Acknowledged as safe to release by agent
-	// 2 - IPAMDoNotRelease : Release request denied by agent
+	// value can be one of the following string :
+	// * marked-for-release : Set by operator as possible candidate for IP
+	// * ready-for-release  : Acknowledged as safe to release by agent
+	// * do-not-release     : IP already in use / not owned by the node. Set by agent
 	//
 	// +optional
-	ReleaseIps map[string]uint8 `json:"release-ips,omitempty"`
+	ReleaseIps map[string]string `json:"release-ips,omitempty"`
 }
 
 // OperatorStatus is the status used by cilium-operator to report

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -126,14 +126,14 @@ type IPAMStatus struct {
 	// +optional
 	OperatorStatus OperatorStatus `json:"operator-status,omitempty"`
 
-	// ReleaseIps tracks the state for every IP considered for release.
+	// ReleaseIPs tracks the state for every IP considered for release.
 	// value can be one of the following string :
 	// * marked-for-release : Set by operator as possible candidate for IP
 	// * ready-for-release  : Acknowledged as safe to release by agent
 	// * do-not-release     : IP already in use / not owned by the node. Set by agent
 	//
 	// +optional
-	ReleaseIps map[string]string `json:"release-ips,omitempty"`
+	ReleaseIPs map[string]string `json:"release-ips,omitempty"`
 }
 
 // OperatorStatus is the status used by cilium-operator to report

--- a/pkg/ipam/types/zz_generated.deepcopy.go
+++ b/pkg/ipam/types/zz_generated.deepcopy.go
@@ -97,7 +97,7 @@ func (in *IPAMStatus) DeepCopyInto(out *IPAMStatus) {
 	out.OperatorStatus = in.OperatorStatus
 	if in.ReleaseIps != nil {
 		in, out := &in.ReleaseIps, &out.ReleaseIps
-		*out = make(map[string]byte, len(*in))
+		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/pkg/ipam/types/zz_generated.deepcopy.go
+++ b/pkg/ipam/types/zz_generated.deepcopy.go
@@ -95,6 +95,13 @@ func (in *IPAMStatus) DeepCopyInto(out *IPAMStatus) {
 		}
 	}
 	out.OperatorStatus = in.OperatorStatus
+	if in.ReleaseIps != nil {
+		in, out := &in.ReleaseIps, &out.ReleaseIps
+		*out = make(map[string]byte, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/ipam/types/zz_generated.deepcopy.go
+++ b/pkg/ipam/types/zz_generated.deepcopy.go
@@ -95,8 +95,8 @@ func (in *IPAMStatus) DeepCopyInto(out *IPAMStatus) {
 		}
 	}
 	out.OperatorStatus = in.OperatorStatus
-	if in.ReleaseIps != nil {
-		in, out := &in.ReleaseIps, &out.ReleaseIps
+	if in.ReleaseIPs != nil {
+		in, out := &in.ReleaseIPs, &out.ReleaseIPs
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -124,8 +124,8 @@ func (in *IPAMStatus) DeepEqual(other *IPAMStatus) bool {
 		return false
 	}
 
-	if ((in.ReleaseIps != nil) && (other.ReleaseIps != nil)) || ((in.ReleaseIps == nil) != (other.ReleaseIps == nil)) {
-		in, other := &in.ReleaseIps, &other.ReleaseIps
+	if ((in.ReleaseIPs != nil) && (other.ReleaseIPs != nil)) || ((in.ReleaseIPs == nil) != (other.ReleaseIPs == nil)) {
+		in, other := &in.ReleaseIPs, &other.ReleaseIPs
 		if other == nil {
 			return false
 		}

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -124,6 +124,27 @@ func (in *IPAMStatus) DeepEqual(other *IPAMStatus) bool {
 		return false
 	}
 
+	if ((in.ReleaseIps != nil) && (other.ReleaseIps != nil)) || ((in.ReleaseIps == nil) != (other.ReleaseIps == nil)) {
+		in, other := &in.ReleaseIps, &other.ReleaseIps
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for key, inValue := range *in {
+				if otherValue, present := (*other)[key]; !present {
+					return false
+				} else {
+					if inValue != otherValue {
+						return false
+					}
+				}
+			}
+		}
+	}
+
 	return true
 }
 


### PR DESCRIPTION
Currently there's a 15 sec delay in updating ciliumnode (CN) CRD after IP allocation to a pod, meanwhile the operator can determine that a node has excess IPs and release the IP causing pod connectivity issues. More details on the race condition https://github.com/cilium/cilium/issues/13412#issuecomment-716516844

Forcing a CN write to go through before allocation can result in too many writes from the agent. 

The operator picks the ENI with the most free IPs to release excess IPs from, this is done so that ENI could potentially be released in the future. An alternative approach considered was to move excess detection logic to the agent, but this involves calling into cloud provider specific implementation, which AFAIK the agent IPAM implementation doesn't.

So, this PR introduces a handshake between the operator and agent before releasing an excess IP to avoid the race condition. A new operator flag `excess-ip-release-delay` is added to control how long operator should wait before considering an IP for release (defaults to 180 secs). This is done to better handle IP reuse during rollouts. Operator and agent use a new map in cilium node status `.status.ipam.release-ips` to exchange information during the handshake.

![full_handshake](https://user-images.githubusercontent.com/3775612/138709486-4a626acf-1ffd-4d13-95d2-6951609eb6a2.png)
