### PR TITLE
Address issue with veth_xmit storing queue in skb

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -812,6 +812,7 @@ int handle_xgress(struct __ctx_buff *ctx)
 	int ret;
 
 	bpf_clear_meta(ctx);
+	ctx->queue_mapping = 0;
 
 	send_trace_notify(ctx, TRACE_FROM_LXC, SECLABEL, 0, 0, 0, 0,
 			  TRACE_PAYLOAD_LEN);


### PR DESCRIPTION
This is a very simplified version of https://github.com/cilium/cilium/pull/18388 as we don't run Cilium on kernels<5.1
I performed a quick test on an experimental cluster and everything worked as expected