### PR TITLE
Cherry-pick: hubble, daemon, operator, option, pprof: Assign specific default port

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -173,6 +173,7 @@ cilium-agent [flags]
       --policy-audit-mode                             Enable policy audit (non-drop) mode
       --policy-queue-size int                         size of queues for policy-related events (default 100)
       --pprof                                         Enable serving the pprof debugging API
+      --pprof-port int                                Port that the pprof listens on (default 6060)
       --preallocate-bpf-maps                          Enable BPF map pre-allocation (default true)
       --prefilter-device string                       Device facing external network for XDP prefiltering (default "undefined")
       --prefilter-mode string                         Prefilter mode via XDP ("native", "generic") (default "native")

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -67,6 +67,7 @@ cilium-operator-aws [flags]
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
+      --pprof-port int                            Port that the pprof listens on (default 6061)
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
       --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -64,6 +64,7 @@ cilium-operator-azure [flags]
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
+      --pprof-port int                            Port that the pprof listens on (default 6061)
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
       --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -62,6 +62,7 @@ cilium-operator-generic [flags]
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
+      --pprof-port int                            Port that the pprof listens on (default 6061)
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
       --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -69,6 +69,7 @@ cilium-operator [flags]
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
+      --pprof-port int                            Port that the pprof listens on (default 6061)
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
       --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -670,6 +670,9 @@ func init() {
 	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
 	option.BindEnv(option.PProf)
 
+	flags.Int(option.PProfPort, 6060, "Port that the pprof listens on")
+	option.BindEnv(option.PProfPort)
+
 	flags.String(option.PrefilterDevice, "undefined", "Device facing external network for XDP prefiltering")
 	option.BindEnv(option.PrefilterDevice)
 
@@ -963,7 +966,7 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if option.Config.PProf {
-		pprof.Enable()
+		pprof.Enable(option.Config.PProfPort)
 	}
 
 	if option.Config.PreAllocateMaps {

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -32,6 +32,7 @@ import (
 type flags struct {
 	debug                  bool
 	pprof                  bool
+	pprofPort              int
 	gops                   bool
 	dialTimeout            time.Duration
 	listenAddress          string
@@ -57,6 +58,9 @@ func New() *cobra.Command {
 	)
 	cmd.Flags().BoolVar(
 		&f.pprof, "pprof", false, "Enable serving the pprof debugging API",
+	)
+	cmd.Flags().IntVar(
+		&f.pprofPort, "pprof-port", defaults.PprofPort, "Port that the pprof listens on",
 	)
 	cmd.Flags().BoolVar(
 		&f.gops, "gops", true, "Run gops agent",
@@ -101,7 +105,7 @@ func runServe(f flags) error {
 		opts = append(opts, server.WithDebug())
 	}
 	if f.pprof {
-		pprof.Enable()
+		pprof.Enable(f.pprofPort)
 	}
 	if f.gops {
 		if err := agent.Listen(agent.Options{}); err != nil {

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -284,6 +284,9 @@ func init() {
 	flags.Bool(operatorOption.PProf, false, "Enable pprof debugging endpoint")
 	option.BindEnv(operatorOption.PProf)
 
+	flags.Int(operatorOption.PProfPort, 6061, "Port that the pprof listens on")
+	option.BindEnv(operatorOption.PProfPort)
+
 	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")
 	option.BindEnv(operatorOption.SyncK8sServices)
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -179,7 +179,7 @@ func runOperator() {
 	}
 
 	if operatorOption.Config.PProf {
-		pprof.Enable()
+		pprof.Enable(operatorOption.Config.PProfPort)
 	}
 
 	k8s.Configure(

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -87,6 +87,9 @@ const (
 	// PProf enabled pprof debugging endpoint
 	PProf = "pprof"
 
+	// PProfPort is the port that the pprof listens on
+	PProfPort = "pprof-port"
+
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices = "synchronize-k8s-services"
 
@@ -249,6 +252,9 @@ type OperatorConfig struct {
 	// PProf enables pprof debugging endpoint
 	PProf bool
 
+	// PProfPort is the port that the pprof listens on
+	PProfPort int
+
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices bool
 
@@ -360,6 +366,7 @@ func (c *OperatorConfig) Populate() {
 	c.OperatorAPIServeAddr = viper.GetString(OperatorAPIServeAddr)
 	c.OperatorPrometheusServeAddr = viper.GetString(OperatorPrometheusServeAddr)
 	c.PProf = viper.GetBool(PProf)
+	c.PProfPort = viper.GetInt(PProfPort)
 	c.SyncK8sServices = viper.GetBool(SyncK8sServices)
 	c.SyncK8sNodes = viper.GetBool(SyncK8sNodes)
 	c.UnmanagedPodWatcherInterval = viper.GetInt(UnmanagedPodWatcherInterval)

--- a/pkg/hubble/relay/defaults/defaults.go
+++ b/pkg/hubble/relay/defaults/defaults.go
@@ -26,6 +26,10 @@ const (
 	// DialTimeout is the timeout that is used when establishing a new
 	// connection.
 	DialTimeout = 5 * time.Second
+	// GopsPort is the default port for gops to listen on.
+	GopsPort = 9893
+	// PprofPort is the default port for pprof to listen on.
+	PprofPort = 6062
 	// RetryTimeout is the duration to wait between reconnection attempts.
 	RetryTimeout = 30 * time.Second
 	// HubbleTarget is the address of the local Hubble instance.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -349,6 +349,9 @@ const (
 	// PProf enables serving the pprof debugging API
 	PProf = "pprof"
 
+	// PProfPort is the port that the pprof listens on
+	PProfPort = "pprof-port"
+
 	// PrefilterDevice is the device facing external network for XDP prefiltering
 	PrefilterDevice = "prefilter-device"
 
@@ -957,6 +960,7 @@ var HelpFlagSections = []FlagsSection{
 			EnableHealthChecking,
 			TracePayloadlen,
 			PProf,
+			PProfPort,
 		},
 	},
 	{
@@ -1562,6 +1566,7 @@ type DaemonConfig struct {
 	TracePayloadlen        int
 	Version                string
 	PProf                  bool
+	PProfPort              int
 	PrometheusServeAddr    string
 	ToFQDNsMinTTL          int
 
@@ -2427,6 +2432,7 @@ func (c *DaemonConfig) Populate() {
 	c.FlannelMasterDevice = viper.GetString(FlannelMasterDevice)
 	c.FlannelUninstallOnExit = viper.GetBool(FlannelUninstallOnExit)
 	c.PProf = viper.GetBool(PProf)
+	c.PProfPort = viper.GetInt(PProfPort)
 	c.PreAllocateMaps = viper.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
 	c.PrometheusServeAddr = getPrometheusServerAddr()

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -16,8 +16,10 @@
 package pprof
 
 import (
+	"net"
 	"net/http"
 	_ "net/http/pprof"
+	"strconv"
 
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -25,10 +27,9 @@ import (
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "pprof")
 
-const apiAddress = "localhost:6060"
-
 // Enable runs an HTTP server to serve the pprof API
-func Enable() {
+func Enable(port int) {
+	var apiAddress = net.JoinHostPort("localhost", strconv.Itoa(port))
 	go func() {
 		if err := http.ListenAndServe(apiAddress, nil); err != nil {
 			log.WithError(err).Warn("Unable to serve pprof API")


### PR DESCRIPTION
This is a cherry-pick of https://github.com/cilium/cilium/commit/4fcc04cd1247cc07d969f185aebbb870f99210f9 with some manual fixes to the hubble code as the code base changed a bit between 1.8 and that commit. This is a follow up change to https://github.com/DataDog/cilium/pull/100 as currently, when the operator starts up with `--pprof` set, it fails to enable the pprof endpoint as the port is already in use by the agent as both the agent and operator are host networked: 
```
level=warning msg="Unable to serve pprof API" error="listen tcp 127.0.0.1:6060: bind: address already in use" subsys=pprof
```
```
root@<snip>:~# ss -tulpn | grep 6060
tcp    LISTEN  0       10240              127.0.0.1:6060          0.0.0.0:*      users:(("cilium-agent",pid=1234,fd=8))
```



If we would prefer to not do this and instead focus on upgrading to 1.10, I'm happy to just close this out and then if desired, also revert https://github.com/DataDog/cilium/pull/100 . 

