### PR TITLE
Adding dedicated ENI ginkgo focus group & e2e tests

### DIFF
--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -117,8 +117,19 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
+      - name: Checkout code
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4
+        with:
+          go-version: 1.17.6
+      - name: Install ginkgo
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@v1.16.5
       - name: Set up job variables
         id: vars
         run: |
@@ -236,6 +247,11 @@ jobs:
       - name: Run connectivity test
         run: |
           cilium connectivity test --flow-validation=disabled
+
+      - name: Run e2e tests
+        run: |
+          cd test
+          ginkgo --focus "Eni" --tags=integration_tests  -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.testScope=eni  -cilium.passCLIEnvironment=true
 
       - name: Clean up Cilium
         run: |

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -117,8 +117,19 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
+      - name: Checkout code
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4
+        with:
+          go-version: 1.17.6
+      - name: Install ginkgo
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@v1.16.5
       - name: Set up job variables
         id: vars
         run: |

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -120,8 +120,19 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
+      - name: Checkout code
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4
+        with:
+          go-version: 1.17.6
+      - name: Install ginkgo
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@v1.16.5
       - name: Set up job variables
         id: vars
         run: |
@@ -230,6 +241,12 @@ jobs:
       - name: Run connectivity test
         run: |
           cilium connectivity test --flow-validation=disabled
+
+      - name: Run e2e tests
+        run: |
+          cd test
+          ginkgo --focus "Eni" --tags=integration_tests  -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.testScope=eni  -cilium.passCLIEnvironment=true
+
 
       # EKS testing with encryption is disabled due to https://github.com/cilium/cilium/issues/16938
       - name: Clean up Cilium

--- a/test/eni/IPRelease.go
+++ b/test/eni/IPRelease.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020-2021 Authors of Cilium
+
+package eniTest
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cilium/cilium/pkg/logging"
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+	"github.com/cilium/cilium/test/nodegroups"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/check.v1"
+)
+
+func getAllocatedIPsOnNode(kubectl *helpers.Kubectl, nodeName string) (int, error) {
+	cn := kubectl.GetCiliumNode(nodeName)
+	if cn == nil {
+		return 0, fmt.Errorf("Unable to fetch cn %s", nodeName)
+	}
+	return len(cn.Spec.IPAM.Pool), nil
+}
+
+func hasRequiredIPsAllocated(kubectl *helpers.Kubectl, nodeName string, n int) func() bool {
+	return func() bool {
+		cn := kubectl.GetCiliumNode(nodeName)
+		if cn == nil {
+			return false
+		}
+		return len(cn.Spec.IPAM.Pool) == n
+	}
+}
+
+func hasRequiredIPBuffer(kubectl *helpers.Kubectl, nodeName string, n int) func() bool {
+	return func() bool {
+		cn := kubectl.GetCiliumNode(nodeName)
+		if cn == nil {
+			return false
+		}
+		return (len(cn.Spec.IPAM.Pool) - len(cn.Status.IPAM.Used)) == n
+	}
+}
+
+func hasNoIPsInHandshake(kubectl *helpers.Kubectl, nodeName string) func() bool {
+	return func() bool {
+		cn := kubectl.GetCiliumNode(nodeName)
+		if cn == nil {
+			return false
+		}
+		return len(cn.Status.IPAM.ReleaseIPs) == 0
+	}
+}
+
+var _ = Describe("EniIPReleaseHandshakeTest", func() {
+	var (
+		kubectl           *helpers.Kubectl
+		ciliumCli         *helpers.CiliumCli
+		deploymentManager *helpers.DeploymentManager
+		releaseTestNs     = "cilium-integration-tests"
+	)
+
+	BeforeAll(func() {
+		var log = logging.DefaultLogger
+		var logger = logrus.NewEntry(log)
+		kubectl = helpers.CreateKubectl("", logger)
+		ciliumCli = helpers.CreateCiliumCli(logger)
+		deploymentManager = helpers.NewDeploymentManager()
+		deploymentManager.SetKubectl(kubectl)
+	})
+
+	AfterAll(func() {
+		deploymentManager.DeleteAll()
+	})
+
+	AfterFailed(func() {
+		kubectl.CiliumReport("cilium status", "cilium endpoint list")
+	})
+
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	It("Test IP release abort", func() {
+		By("Enabling aws excess IP release feature and restarting cilium operator")
+		err := ciliumCli.UpdateCiliumConfig("aws-release-excess-ips", "true", false)
+		Expect(err).NotTo(HaveOccurred())
+		err = ciliumCli.UpdateCiliumConfig("excess-ip-release-delay", "30", false)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Workaround till cilium-cli supports restarting operator based on config change
+		err = kubectl.RestartOperator()
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Create nodegroup to deploy tests on")
+		ng := nodegroups.EksNodegroup{NodePool: nodegroups.NodePool{
+			Name:          "ip-release",
+			ClusterName:   os.Getenv("clusterName"),
+			InstanceTypes: []string{"t3.medium", "t3a.medium"},
+			Region:        os.Getenv("region"),
+			NumNodes:      1,
+			NodeTaint:     "ip-release",
+			Executor:      helpers.CreateLocalExecutor(os.Environ()),
+			Kubectl:       kubectl,
+		}}
+		err = ng.CreateNodePool()
+		Expect(err).NotTo(HaveOccurred(), "Error while creating nodegroup")
+
+		By("Creating a deployment to pick a node to test on")
+		configFile := "nginx-with-tolerations.yaml"
+		labelSelector := "zgroup=http-server"
+		tmpl := helpers.ManifestGet(kubectl.BasePath(), "http-deployment-node-toleration.yaml.tmpl")
+		helpers.RenderTemplateWithData(tmpl, configFile, struct{ NodeTaint string }{NodeTaint: "ip-release"})
+
+		_ = kubectl.Exec(fmt.Sprintf("kubectl create ns %s", releaseTestNs))
+		res := kubectl.Exec(fmt.Sprintf("kubectl -n %s apply -f %s", releaseTestNs, configFile))
+		if !res.WasSuccessful() {
+			Failf("error creating test workload %v", res.OutputPrettyPrint())
+		}
+		kubectl.WaitforNPodsRunning(releaseTestNs, "-l "+labelSelector, 2, 10*time.Minute)
+
+		By("Fetching cilium node for test pods")
+		data, err := kubectl.GetPodsNodes(releaseTestNs, labelSelector)
+		if err != nil {
+			Fail(err.Error())
+		}
+		var nodeName string
+		for _, v := range data {
+			nodeName = v
+			break
+		}
+
+		cn := kubectl.GetCiliumNode(nodeName)
+		Expect(cn).NotTo(Equal(check.IsNil))
+		totalBuffer := cn.Spec.IPAM.PreAllocate + cn.Spec.IPAM.MaxAboveWatermark
+
+		By("Wait for new IPs to be allocated, IP Buffer : %v", totalBuffer)
+		err = helpers.WithTimeout(hasRequiredIPBuffer(kubectl, nodeName, totalBuffer), "Timeout while waiting for new IPs to be allocated",
+			&helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for new IPs to be allocated")
+
+		initialAllocCnt, err := getAllocatedIPsOnNode(kubectl, nodeName)
+		Expect(err).NotTo(Equal(check.IsNil))
+
+		By("Scaling replicas by 2")
+		res = kubectl.Exec(fmt.Sprintf("kubectl -n %s scale deploy %s --replicas=%v", releaseTestNs, "http-server", 4))
+		if !res.WasSuccessful() {
+			Failf("Error while scaling replicas %v", err.Error())
+		}
+
+		By("Wait for new pods to start up")
+		kubectl.WaitforNPodsRunning(releaseTestNs, "-l "+labelSelector, 4, helpers.HelperTimeout)
+
+		By("Wait for new IPs to be allocated")
+		err = helpers.WithTimeout(hasRequiredIPBuffer(kubectl, nodeName, totalBuffer), "Timeout while waiting for new IPs to be allocated",
+			&helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for new IPs to be allocated")
+
+		By("Scale back by 2 to create excess")
+		res = kubectl.Exec(fmt.Sprintf("kubectl -n %s scale deploy %s --replicas=%v", releaseTestNs, "http-server", 2))
+		if !res.WasSuccessful() {
+			Failf("Error while scaling replicas %v", err.Error())
+		}
+
+		By("Wait for IPs to be released from the pool. Waiting for total IPs=%v", initialAllocCnt)
+		err = helpers.WithTimeout(hasRequiredIPsAllocated(kubectl, nodeName, initialAllocCnt), "Timeout while waiting for IPs to be released from pool",
+			&helpers.TimeoutConfig{Timeout: 10 * time.Minute})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for IPs to be released from pool")
+
+		By("Wait for entries to be cleared from release status")
+		err = helpers.WithTimeout(hasNoIPsInHandshake(kubectl, nodeName), "Timeout while waiting for entries to be cleared from release status",
+			&helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for entries to be cleared from release status")
+	})
+
+})

--- a/test/helpers/cilium-cli.go
+++ b/test/helpers/cilium-cli.go
@@ -1,0 +1,43 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/test/config"
+)
+
+const (
+	CiliumCliCmd = "cilium"
+)
+
+type CiliumCli struct {
+	executor Executor
+	log      *logrus.Entry
+}
+
+func CreateCiliumCli(log *logrus.Entry) (c *CiliumCli) {
+	var environ []string
+	if config.CiliumTestConfig.PassCLIEnvironment {
+		environ = append(environ, os.Environ()...)
+	}
+	environ = append(environ, "KUBECONFIG="+config.CiliumTestConfig.Kubeconfig)
+	environ = append(environ, fmt.Sprintf("PATH=%s:%s", GetKubectlPath(), os.Getenv("PATH")))
+
+	c = &CiliumCli{
+		executor: CreateLocalExecutor(environ),
+		log:      log,
+	}
+	return c
+}
+
+func (c *CiliumCli) UpdateCiliumConfig(key string, val string, restart bool) error {
+	res := c.executor.ExecShort(fmt.Sprintf("%s config set --restart=%v %s %s", CiliumCliCmd, restart, key, val))
+
+	if !res.WasSuccessful() {
+		return fmt.Errorf("unable to update config with error %s", res.OutputPrettyPrint())
+	}
+	return nil
+}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -853,6 +854,40 @@ func (kub *Kubectl) GetCNP(namespace string, cnp string) *cnpv2.CiliumNetworkPol
 		return nil
 	}
 	return &result
+}
+
+// GetCiliumNode retrieves the output of `kubectl get cnp` in the given namespace for
+// the given CNP and return a CNP struct. If the CNP does not exists or cannot
+// unmarshal the Json output will return nil.
+func (kub *Kubectl) GetCiliumNode(ciliumNode string) *cnpv2.CiliumNode {
+	log := kub.Logger().WithFields(logrus.Fields{
+		"fn":  "GetCiliumNode",
+		"cnp": ciliumNode,
+	})
+	res := kub.Get("''", fmt.Sprintf("cn %s", ciliumNode))
+	if !res.WasSuccessful() {
+		log.WithField("error", res.CombineOutput()).Info("cannot get CN")
+		return nil
+	}
+	var result cnpv2.CiliumNode
+	err := res.Unmarshal(&result)
+	if err != nil {
+		log.WithError(err).Errorf("cannot unmarshal CN output")
+		return nil
+	}
+	return &result
+}
+
+func (kub *Kubectl) RestartOperator() error {
+	res := kub.DeleteResource("pod", "-n "+KubeSystemNamespace+" -l "+CiliumOperatorLabel)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("cannot delete operator with error : %s", res.OutputPrettyPrint())
+	}
+	res = kub.Exec(fmt.Sprintf("%s -n %s wait --for=condition=ready pod -l %s --timeout=180s", KubectlCmd, CiliumNamespaceDefault, CiliumOperatorLabel))
+	if !res.WasSuccessful() {
+		return fmt.Errorf("timeout while waiting for operator to be ready")
+	}
+	return nil
 }
 
 func (kub *Kubectl) WaitForCRDCount(filter string, count int, timeout time.Duration) error {
@@ -4591,8 +4626,8 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 		rcVersion = fmt.Sprintf("v%s.0", GetCurrentK8SEnv())
 	}
 	res = kub.Exec(
-		fmt.Sprintf("curl --output %s https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
-			path, rcVersion, path))
+		fmt.Sprintf("curl --output %s https://storage.googleapis.com/kubernetes-release/release/%s/bin/%s/%s/kubectl && chmod +x %s",
+			path, rcVersion, runtime.GOOS, runtime.GOARCH, path))
 	if !res.WasSuccessful() {
 		return fmt.Errorf("failed to download kubectl")
 	}

--- a/test/helpers/scope.go
+++ b/test/helpers/scope.go
@@ -30,6 +30,8 @@ func GetScope() (string, error) {
 	case strings.Contains(focusString, "nightly"):
 		// Nightly tests run in a Kubernetes environment.
 		return K8s, nil
+	case strings.Contains(focusString, "eni"):
+		return "Eni", nil
 	default:
 		return "", errors.New("Scope cannot be set")
 	}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -85,6 +85,23 @@ func RenderTemplate(tmplt string) (*bytes.Buffer, error) {
 	return content, nil
 }
 
+func RenderTemplateWithData(sourcePath string, destPath string, data interface{}) error {
+	tmpl, err := template.ParseFiles(sourcePath)
+	if err != nil {
+		return fmt.Errorf("error while parsing template : %v", err.Error())
+	}
+	f, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("error while opening destination file : %v", err.Error())
+	}
+	defer f.Close()
+	err = tmpl.Execute(f, data)
+	if err != nil {
+		return fmt.Errorf("error while rendering template : %v", err.Error())
+	}
+	return nil
+}
+
 // TimeoutConfig represents the configuration for the timeout of a command.
 type TimeoutConfig struct {
 	Ticker  time.Duration // Check interval

--- a/test/k8sT/manifests/eks-nodegroup.yaml.tmpl
+++ b/test/k8sT/manifests/eks-nodegroup.yaml.tmpl
@@ -1,0 +1,24 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: {{ .ClusterName }}
+  region: {{ .Region }}
+managedNodeGroups:
+  - name: {{ .Name }}
+    labels: { role: {{ .NodeTaint }} }
+    instanceTypes:
+    {{range .InstanceTypes}}
+    - {{ . }}
+    {{end}}
+    desiredCapacity: {{ .NumNodes }}
+    spot: true
+    privateNetworking: true
+    volumeType: "gp3"
+    volumeSize: 10
+    taints:
+      - key: "node.cilium.io/agent-not-ready"
+        value: "true"
+        effect: "NoSchedule"
+      - key: {{ .NodeTaint }}
+        value: "true"
+        effect: "NoSchedule"

--- a/test/k8sT/manifests/http-deployment-node-toleration.yaml.tmpl
+++ b/test/k8sT/manifests/http-deployment-node-toleration.yaml.tmpl
@@ -1,0 +1,26 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: http-server
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+        zgroup: http-server
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/library/nginx:1.19.4
+          ports:
+            - containerPort: 80
+      tolerations:
+        - key: {{ .NodeTaint }}
+          operator: "Exists"
+          effect: "NoSchedule"
+      nodeSelector:
+        role: {{ .NodeTaint }}

--- a/test/nodegroups/nodegroups.go
+++ b/test/nodegroups/nodegroups.go
@@ -1,0 +1,70 @@
+package nodegroups
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/test/helpers"
+)
+
+const (
+	EksCliCmd = "eksctl"
+	AksCliCmd = "az"
+	GKECliCmd = "gcloud"
+)
+
+type NodePool struct {
+	Name          string
+	ClusterName   string
+	InstanceTypes []string
+	Region        string
+	// Number of nodes for fixed size node pools
+	NumNodes int
+	// Min number of nodes in the nodepool
+	MinNodes int
+	// Taint to be added to the nodes created in this nodepool
+	NodeTaint string
+	Executor  *helpers.LocalExecutor
+	Kubectl   *helpers.Kubectl
+}
+
+type EksNodegroup struct {
+	NodePool
+}
+
+type NodePoolImpl interface {
+	CreateNodePool() error
+	DeleteNodePool() error
+	ScaleNodePool() error
+}
+
+func (e *EksNodegroup) CreateNodePool() error {
+	configFile := e.Name + ".yaml"
+	tmpl := helpers.ManifestGet(e.Kubectl.BasePath(), "eks-nodegroup.yaml.tmpl")
+	err := helpers.RenderTemplateWithData(tmpl, configFile, e.NodePool)
+	if err != nil {
+		return err
+	}
+	cmd := fmt.Sprintf("%s create nodegroup --config-file=%s", EksCliCmd, configFile)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	res := e.Executor.ExecContext(ctx, cmd)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("unable to create eks nodegroup : %s", res.OutputPrettyPrint())
+	}
+	return nil
+}
+
+func (e *EksNodegroup) DeleteNodePool() error {
+	cmd := fmt.Sprintf("%s delete nodegroup --cluster=%s -n=%s", EksCliCmd, e.ClusterName, e.Name)
+	res := e.Executor.ExecMiddle(cmd)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("unable to create eks nodegroup : %s", res.OutputPrettyPrint())
+	}
+	return nil
+}
+
+func (e *EksNodegroup) ScaleNodePool() error {
+	return fmt.Errorf("scaling nodegroup is not implemented yet")
+}

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -150,7 +150,11 @@ func reportCreateVMFailure(vm string, err error) {
 
 var _ = BeforeAll(func() {
 	helpers.Init()
-	By("Starting tests: command line parameters: %+v environment variables: %v", config.CiliumTestConfig, os.Environ())
+	var envToPrint []string
+	if os.Getenv("GITHUB_ACTIONS") != "true" {
+		envToPrint = os.Environ()
+	}
+	By("Starting tests: command line parameters: %+v environment variables: %v", config.CiliumTestConfig, envToPrint)
 	go func() {
 		defer GinkgoRecover()
 		time.Sleep(config.CiliumTestConfig.Timeout)

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -8,6 +8,7 @@ package ciliumTest
 
 import (
 	// test sources
+	_ "github.com/cilium/cilium/test/eni"
 	_ "github.com/cilium/cilium/test/k8sT"
 	_ "github.com/cilium/cilium/test/runtime"
 )


### PR DESCRIPTION
Currently there is no way to write e2e tests exclusive to a cloud provider.
This commit introduces a new focus group for ENI, which can be used to
house e2e tests for cloud provider specific features like AWS excess IP
release, ENI prefix delegation, etc. There are more features that aren't
currently tested e2e in CI and this focus group makes it easy to add them.
This commit also includes an e2e test for IP release.

Signed-off-by: Hemanth Malla <hemanth.malla@datadoghq.com>
