### PR TITLE
Cherry pick: ipam: Fix empty interface number in Azure

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -632,6 +632,18 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 			if iface.ID == ipInfo.Resource {
 				result.PrimaryMAC = iface.MAC
 				result.GatewayIP = iface.GatewayIP
+				// For now, we can hardcode the interface number to a valid
+				// integer because it will not be used in the allocation result
+				// anyway. To elaborate, Azure IPAM mode automatically sets
+				// option.Config.EgressMultiHomeIPRuleCompat to true, meaning
+				// that the CNI will not use the interface number when creating
+				// the pod rules and routes. We are hardcoding simply to bypass
+				// the parsing errors when InterfaceNumber is empty. See
+				// https://github.com/cilium/cilium/issues/15496.
+				//
+				// TODO: Once https://github.com/cilium/cilium/issues/14705 is
+				// resolved, then we don't need to hardcode this anymore.
+				result.InterfaceNumber = "0"
 				return
 			}
 		}


### PR DESCRIPTION
This PR cherry-picks the work done in https://github.com/cilium/cilium/commit/261fae47349e1bd5bb693d86b0fe7e23960d58ac back to 1.8.

I also did a quick sanity check and confirmed that this logic is still present in the latest release: https://github.com/cilium/cilium/blob/c5f7b0112e518e3901390968d0c0f4cf4182dda0/pkg/ipam/crd.go#L628-L648