### PR TITLE
Testing workflows for ENI e2e tests

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -57,7 +57,7 @@ jobs:
         id: tag-in-repositories
         shell: bash
         run: |
-          if docker buildx imagetools inspect quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{  steps.tag.outputs.tag }} &>/dev/null; then
+          if docker buildx imagetools inspect public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}:${{  steps.tag.outputs.tag }} &>/dev/null; then
             echo ::set-output name=exists::"true"
           else
             echo ::set-output name=exists::"false"
@@ -67,7 +67,7 @@ jobs:
         if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}
         uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7
         with:
-          registry: quay.io
+          registry: public.ecr.aws
           username: ${{ secrets.QUAY_BASE_RELEASE_USERNAME }}
           password: ${{ secrets.QUAY_BASE_RELEASE_PASSWORD }}
 
@@ -81,7 +81,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
 
       - name: Image Release Digest
         if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}
@@ -90,7 +90,7 @@ jobs:
           mkdir -p image-digest/
           echo "## ${{ matrix.name }}" > image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
-          echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
 
       - name: Upload artifact digests

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Login to quay.io
         uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7
         with:
-          registry: quay.io
+          registry: public.ecr.aws
           username: ${{ secrets.QUAY_BETA_USERNAME }}
           password: ${{ secrets.QUAY_BETA_PASSWORD }}
 
@@ -67,7 +67,7 @@ jobs:
         id: tag-in-repositories
         shell: bash
         run: |
-          if docker buildx imagetools inspect quay.io/${{ github.repository_owner }}/${{ matrix.name }}-${{ github.event.inputs.suffix }}:${{ github.event.inputs.tag }} &>/dev/null; then
+          if docker buildx imagetools inspect public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-${{ github.event.inputs.suffix }}:${{ github.event.inputs.tag }} &>/dev/null; then
             echo "Tag already exists!"
             exit 1
           fi
@@ -86,8 +86,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-${{ github.event.inputs.suffix }}:${{ github.event.inputs.tag }}
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-${{ github.event.inputs.suffix }}:${{ github.event.inputs.tag }}
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ github.sha }}
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
 
@@ -97,8 +97,8 @@ jobs:
           mkdir -p image-digest/
           echo "## ${{ matrix.name }}" > image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
-          echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}-${{ github.event.inputs.suffix }}:${{ github.event.inputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
-          echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-${{ github.event.inputs.suffix }}:${{ github.event.inputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ github.sha }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Login to quay.io for CI
         uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7
         with:
-          registry: quay.io
+          registry: public.ecr.aws
           username: ${{ secrets.QUAY_USERNAME_CI }}
           password: ${{ secrets.QUAY_PASSWORD_CI }}
 
@@ -126,8 +126,8 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64,linux/arm64
           tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:latest
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
 
@@ -144,8 +144,8 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64
           tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest-race
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:latest-race
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race
           build-args: |
             BASE_IMAGE=quay.io/cilium/cilium-runtime:05aefca72c6e53861ebd2e0892946e73abbd9d38@sha256:3c5b6d80c0596d952948f5330afed096cdc32f23e7b90161a89632a392734761
             LOCKDEBUG=1
@@ -157,10 +157,10 @@ jobs:
         shell: bash
         run: |
           mkdir -p image-digest/
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest@${{ steps.docker_build_ci_master.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest-race@${{ steps.docker_build_ci_master_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_master.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race@${{ steps.docker_build_ci_master_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:latest@${{ steps.docker_build_ci_master.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+          echo "public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:latest-race@${{ steps.docker_build_ci_master_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_master.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race@${{ steps.docker_build_ci_master_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
 
       # PR updates
       - name: CI Build ${{ matrix.name }}
@@ -173,7 +173,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
 
@@ -182,7 +182,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p image-digest/
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_pr.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+          echo "public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_pr.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
 
       - name: CI race detection Build ${{ matrix.name }}
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -194,7 +194,7 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race
           build-args: |
             BASE_IMAGE=quay.io/cilium/cilium-runtime:05aefca72c6e53861ebd2e0892946e73abbd9d38@sha256:3c5b6d80c0596d952948f5330afed096cdc32f23e7b90161a89632a392734761
             LOCKDEBUG=1
@@ -206,8 +206,8 @@ jobs:
         shell: bash
         run: |
           mkdir -p image-digest/
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_pr.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race@${{ steps.docker_build_ci_pr_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_pr.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race@${{ steps.docker_build_ci_pr_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests
       - name: Upload artifact digests
@@ -265,7 +265,7 @@ jobs:
       - name: Login to quay.io for CI
         uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7
         with:
-          registry: quay.io
+          registry: public.ecr.aws
           username: ${{ secrets.QUAY_USERNAME_CI }}
           password: ${{ secrets.QUAY_PASSWORD_CI }}
 
@@ -315,15 +315,15 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64,linux/arm64
           tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:latest
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ github.sha }}
 
       - name: CI Image Releases digests
         shell: bash
         run: |
           mkdir -p image-digest/
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest@${{ steps.docker_build_ci_master.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}@${{ steps.docker_build_ci_master.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:latest@${{ steps.docker_build_ci_master.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+          echo "public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ github.sha }}@${{ steps.docker_build_ci_master.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests
       - name: Upload artifact digests

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Login to quay.io
         uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7
         with:
-          registry: quay.io
+          registry: public.ecr.aws
           username: ${{ secrets.QUAY_DEVELOPER_USERNAME }}
           password: ${{ secrets.QUAY_DEVELOPER_PASSWORD }}
 
@@ -61,7 +61,7 @@ jobs:
         id: tag-in-repositories
         shell: bash
         run: |
-          if docker buildx imagetools inspect quay.io/${{ github.repository_owner }}/${{ matrix.name }}-dev:${{ steps.tag.outputs.tag }} &>/dev/null; then
+          if docker buildx imagetools inspect public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-dev:${{ steps.tag.outputs.tag }} &>/dev/null; then
             echo "Tag already exists!"
             exit 1
           fi
@@ -80,8 +80,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-dev:${{ steps.tag.outputs.tag }}
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-dev:${{ steps.tag.outputs.tag }}
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ github.sha }}
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
 
@@ -91,8 +91,8 @@ jobs:
           mkdir -p image-digest/
           echo "## ${{ matrix.name }}" > image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
-          echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}-dev:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
-          echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-dev:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ github.sha }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Login to quay.io
         uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7
         with:
-          registry: quay.io
+          registry: public.ecr.aws
           username: ${{ secrets.QUAY_USERNAME_RELEASE_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD_RELEASE_PASSWORD }}
 
@@ -78,9 +78,9 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
+            datadog/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+            public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}-ci:${{ github.sha }}
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
 
@@ -95,8 +95,8 @@ jobs:
 
           echo "### ${{ matrix.name }}" > image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
-          echo "\`docker.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
-          echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`docker.io/datadog/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`public.ecr.aws/b1o7r7e0/cilium/datadog/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests

--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -61,7 +61,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  name: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
   cilium_cli_version: v0.10.1
@@ -136,15 +136,15 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.name }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-azure-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-azure-ci \
             --version=${SHA} \
             --azure-resource-group ${{ env.name }} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
             --base-version=v1.10"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -187,7 +187,7 @@ jobs:
           az group create \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
-            --tags usage=${{ github.repository_owner }}-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
+            --tags usage=datadog-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
 
           # Create AKS cluster
           az aks create \
@@ -242,7 +242,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-azure-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -61,7 +61,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  name: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
   cilium_cli_version: v0.10.1
@@ -136,15 +136,15 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.name }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-azure-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-azure-ci \
             --version=${SHA} \
             --azure-resource-group ${{ env.name }} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
             --base-version=v1.11"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -187,7 +187,7 @@ jobs:
           az group create \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
-            --tags usage=${{ github.repository_owner }}-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
+            --tags usage=datadog-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
 
           # Create AKS cluster
           az aks create \
@@ -242,7 +242,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-azure-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -64,7 +64,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  name: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
   cilium_cli_version: v0.10.1
@@ -139,14 +139,14 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.name }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-azure-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-azure-ci \
             --version=${SHA} \
             --azure-resource-group ${{ env.name }} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -189,7 +189,7 @@ jobs:
           az group create \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
-            --tags usage=${{ github.repository_owner }}-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
+            --tags usage=datadog-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
 
           # Create AKS cluster
           az aks create \
@@ -244,7 +244,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-azure-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -61,7 +61,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -178,7 +178,7 @@ jobs:
               name: ${{ env.clusterName }}
               region: ${{ env.region }}
               tags:
-               usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
+               usage: "datadog-${{ github.event.repository.name }}"
                owner: "${{ steps.vars.outputs.owner }}"
 
             managedNodeGroups:
@@ -208,7 +208,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium
@@ -218,9 +218,9 @@ jobs:
           cd cilium-master/install/kubernetes
           helm install cilium ./cilium \
             --namespace kube-system \
-            --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
+            --set image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
             --set image.tag=${{ steps.vars.outputs.sha }} \
-            --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
+            --set operator.image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/operator \
             --set operator.image.suffix="-ci" \
             --set operator.image.tag=${{ steps.vars.outputs.sha }} \
             --set cni.chainingMode=aws-cni \
@@ -237,7 +237,7 @@ jobs:
             --namespace kube-system \
             --reuse-values \
             --set hubble.relay.enabled=true \
-            --set hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+            --set hubble.relay.image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --set hubble.relay.image.tag=${{ steps.vars.outputs.sha }}
 
       - name: Wait for Cilium status to be ready

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -61,7 +61,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -178,7 +178,7 @@ jobs:
               name: ${{ env.clusterName }}
               region: ${{ env.region }}
               tags:
-               usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
+               usage: "datadog-${{ github.event.repository.name }}"
                owner: "${{ steps.vars.outputs.owner }}"
 
             managedNodeGroups:
@@ -208,7 +208,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium
@@ -218,9 +218,9 @@ jobs:
           cd cilium-master/install/kubernetes
           helm install cilium ./cilium \
             --namespace kube-system \
-            --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
+            --set image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
             --set image.tag=${{ steps.vars.outputs.sha }} \
-            --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
+            --set operator.image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/operator \
             --set operator.image.suffix="-ci" \
             --set operator.image.tag=${{ steps.vars.outputs.sha }} \
             --set cni.chainingMode=aws-cni \
@@ -237,7 +237,7 @@ jobs:
             --namespace kube-system \
             --reuse-values \
             --set hubble.relay.enabled=true \
-            --set hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+            --set hubble.relay.image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --set hubble.relay.image.tag=${{ steps.vars.outputs.sha }}
 
       - name: Wait for Cilium status to be ready

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -64,7 +64,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -181,7 +181,7 @@ jobs:
               name: ${{ env.clusterName }}
               region: ${{ env.region }}
               tags:
-               usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
+               usage: "datadog-${{ github.event.repository.name }}"
                owner: "${{ steps.vars.outputs.owner }}"
 
             managedNodeGroups:
@@ -211,7 +211,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium
@@ -221,9 +221,9 @@ jobs:
           cd cilium-master/install/kubernetes
           helm install cilium ./cilium \
             --namespace kube-system \
-            --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
+            --set image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
             --set image.tag=${{ steps.vars.outputs.sha }} \
-            --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
+            --set operator.image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/operator \
             --set operator.image.suffix="-ci" \
             --set operator.image.tag=${{ steps.vars.outputs.sha }} \
             --set cni.chainingMode=aws-cni \
@@ -240,7 +240,7 @@ jobs:
             --namespace kube-system \
             --reuse-values \
             --set hubble.relay.enabled=true \
-            --set hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+            --set hubble.relay.image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --set hubble.relay.image.tag=${{ steps.vars.outputs.sha }}
 
       - name: Wait for Cilium status to be ready

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -61,7 +61,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -135,14 +135,14 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-aws-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-aws-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
             --base-version=v1.10"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -190,7 +190,7 @@ jobs:
             name: ${{ env.clusterName }}
             region: ${{ env.region }}
             tags:
-             usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
+             usage: "datadog-${{ github.event.repository.name }}"
              owner: "${{ steps.vars.outputs.owner }}"
 
           managedNodeGroups:
@@ -216,7 +216,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-aws-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -237,6 +237,11 @@ jobs:
         run: |
           cilium connectivity test --flow-validation=disabled
 
+      - name: Run e2e tests
+        run: |
+          cd test
+          ginkgo --focus "Eni" --tags=integration_tests  -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.testScope=eni  -cilium.passCLIEnvironment=true
+
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -61,7 +61,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -135,14 +135,14 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-aws-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-aws-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
             --base-version=v1.11"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -190,7 +190,7 @@ jobs:
             name: ${{ env.clusterName }}
             region: ${{ env.region }}
             tags:
-             usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
+             usage: "datadog-${{ github.event.repository.name }}"
              owner: "${{ steps.vars.outputs.owner }}"
 
           managedNodeGroups:
@@ -216,7 +216,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-aws-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -64,7 +64,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -138,13 +138,13 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-aws-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-aws-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -192,7 +192,7 @@ jobs:
             name: ${{ env.clusterName }}
             region: ${{ env.region }}
             tags:
-             usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
+             usage: "datadog-${{ github.event.repository.name }}"
              owner: "${{ steps.vars.outputs.owner }}"
 
           managedNodeGroups:
@@ -218,7 +218,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-aws-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -7,7 +7,7 @@ on:
       - created
   # Run every 6 hours
   schedule:
-    - cron:  '0 1/6 * * *'
+    - cron: '0 1/6 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `master`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not
@@ -65,7 +65,7 @@ concurrency:
 
 env:
   clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
-  region: us-east-2
+  region: us-west-2
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -122,6 +122,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Checkout code
+        if: ${{ github.event.issue.pull_request }}
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
       - name: Set up job variables
         id: vars
         run: |
@@ -141,7 +146,7 @@ jobs:
             --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
             --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-aws-ci \
             --version=${SHA} \
-            --wait=false \
+            --wait=true \
             --rollback=false \
             --config monitor-aggregation=none"
           HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
@@ -213,14 +218,6 @@ jobs:
 
           eksctl create cluster -f ./eks-config.yaml
 
-      - name: Wait for images to be available
-        timeout-minutes: 10
-        shell: bash
-        run: |
-          for image in cilium-ci operator-aws-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
-          done
-
       - name: Install Cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
@@ -238,6 +235,12 @@ jobs:
       - name: Run connectivity test
         run: |
           cilium connectivity test --flow-validation=disabled
+
+      - name: Run e2e tests
+        run: |
+          cd test
+          ginkgo --focus "Eni" --tags=integration_tests  -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.testScope=eni  -cilium.passCLIEnvironment=true
+
 
       # EKS testing with encryption is disabled due to https://github.com/cilium/cilium/issues/16938
       - name: Clean up Cilium

--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -61,8 +61,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
-  vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-vm
+  vmName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
   cilium_cli_version: v0.10.1
@@ -137,8 +137,8 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-generic-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
@@ -146,9 +146,9 @@ jobs:
             --config tunnel=vxlan \
             --kube-proxy-replacement=strict \
             --base-version=v1.10"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
-          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \
+          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=public.ecr.aws/b1o7r7e0/cilium/datadog/clustermesh-apiserver-ci \
             --apiserver-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -198,7 +198,7 @@ jobs:
           max_attempts: 10
           command: |
             gcloud compute instances create ${{ env.vmName }} \
-              --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+              --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
               --zone ${{ env.zone }} \
               --machine-type e2-custom-2-4096 \
               --boot-disk-type pd-standard \
@@ -212,7 +212,7 @@ jobs:
       - name: Create GKE cluster
         run: |
           gcloud container clusters create ${{ env.clusterName }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
             --image-type COS_CONTAINERD \
@@ -231,7 +231,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium in cluster

--- a/.github/workflows/conformance-externalworkloads-v1.11.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yml
@@ -61,8 +61,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
-  vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-vm
+  vmName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
   cilium_cli_version: v0.10.1
@@ -137,8 +137,8 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-generic-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
@@ -146,9 +146,9 @@ jobs:
             --config tunnel=vxlan \
             --kube-proxy-replacement=strict \
             --base-version=v1.11"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
-          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \
+          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=public.ecr.aws/b1o7r7e0/cilium/datadog/clustermesh-apiserver-ci \
             --apiserver-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -198,7 +198,7 @@ jobs:
           max_attempts: 10
           command: |
             gcloud compute instances create ${{ env.vmName }} \
-              --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+              --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
               --zone ${{ env.zone }} \
               --machine-type e2-custom-2-4096 \
               --boot-disk-type pd-standard \
@@ -212,7 +212,7 @@ jobs:
       - name: Create GKE cluster
         run: |
           gcloud container clusters create ${{ env.clusterName }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
             --image-type COS_CONTAINERD \
@@ -231,7 +231,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium in cluster

--- a/.github/workflows/conformance-externalworkloads.yml
+++ b/.github/workflows/conformance-externalworkloads.yml
@@ -64,8 +64,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
-  vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-vm
+  vmName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
   cilium_cli_version: v0.10.1
@@ -140,17 +140,17 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-generic-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
             --config tunnel=vxlan \
             --kube-proxy-replacement=strict"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
-          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \
+          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=public.ecr.aws/b1o7r7e0/cilium/datadog/clustermesh-apiserver-ci \
             --apiserver-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -200,7 +200,7 @@ jobs:
           max_attempts: 10
           command: |
             gcloud compute instances create ${{ env.vmName }} \
-              --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+              --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
               --zone ${{ env.zone }} \
               --machine-type e2-custom-2-4096 \
               --boot-disk-type pd-standard \
@@ -214,7 +214,7 @@ jobs:
       - name: Create GKE cluster
         run: |
           gcloud container clusters create ${{ env.clusterName }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
             --image-type COS_CONTAINERD \
@@ -233,7 +233,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium in cluster

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -61,7 +61,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -135,14 +135,14 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-generic-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
             --base-version=v1.10"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -181,7 +181,7 @@ jobs:
       - name: Create GKE cluster
         run: |
           gcloud container clusters create ${{ env.clusterName }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
@@ -200,7 +200,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -61,7 +61,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -135,14 +135,14 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-generic-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
             --base-version=v1.11"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -181,7 +181,7 @@ jobs:
       - name: Create GKE cluster
         run: |
           gcloud container clusters create ${{ env.clusterName }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
@@ -200,7 +200,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -64,7 +64,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+  clusterName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -138,13 +138,13 @@ jobs:
           fi
 
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
-            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+            --agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-generic-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -183,7 +183,7 @@ jobs:
       - name: Create GKE cluster
         run: |
           gcloud container clusters create ${{ env.clusterName }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
@@ -202,7 +202,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -59,8 +59,8 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
-          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
-          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/operator-generic-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/cilium-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/operator-generic-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
 
       - name: Create kind cluster
         uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478
@@ -81,11 +81,11 @@ jobs:
              --set hostPort.enabled=true \
              --set bpf.masquerade=false \
              --set ipam.mode=kubernetes \
-             --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
+             --set image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
              --set image.tag=${{ steps.vars.outputs.tag }} \
              --set image.pullPolicy=IfNotPresent \
              --set image.useDigest=false \
-             --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
+             --set operator.image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/operator \
              --set operator.image.suffix=-ci \
              --set operator.image.tag=${{ steps.vars.outputs.tag }} \
              --set operator.image.pullPolicy=IfNotPresent \

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -39,13 +39,13 @@ jobs:
             SHA=${{ github.sha }}
           fi
 
-          CILIUM_INSTALL_DEFAULTS="--agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+          CILIUM_INSTALL_DEFAULTS="--agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-generic-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -75,7 +75,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -61,10 +61,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName1: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-1
-  clusterName2: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
+  clusterName1: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-1
+  clusterName2: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
   zone: us-west2-a
-  firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
+  firewallRuleName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-rule
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -136,16 +136,16 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          CILIUM_INSTALL_DEFAULTS="--agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+          CILIUM_INSTALL_DEFAULTS="--agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-generic-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
             --base-version=v1.10"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
-          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \
+          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=public.ecr.aws/b1o7r7e0/cilium/datadog/clustermesh-apiserver-ci \
             --apiserver-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -185,7 +185,7 @@ jobs:
       - name: Create GKE cluster 1
         run: |
           gcloud container clusters create ${{ env.clusterName1 }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
@@ -199,7 +199,7 @@ jobs:
       - name: Create GKE cluster 2
         run: |
           gcloud container clusters create ${{ env.clusterName2 }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
@@ -234,7 +234,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium in cluster1

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -61,10 +61,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName1: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-1
-  clusterName2: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
+  clusterName1: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-1
+  clusterName2: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
   zone: us-west2-a
-  firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
+  firewallRuleName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-rule
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -136,16 +136,16 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          CILIUM_INSTALL_DEFAULTS="--agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+          CILIUM_INSTALL_DEFAULTS="--agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-generic-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
             --base-version=v1.11"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
-          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \
+          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=public.ecr.aws/b1o7r7e0/cilium/datadog/clustermesh-apiserver-ci \
             --apiserver-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -185,7 +185,7 @@ jobs:
       - name: Create GKE cluster 1
         run: |
           gcloud container clusters create ${{ env.clusterName1 }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
@@ -199,7 +199,7 @@ jobs:
       - name: Create GKE cluster 2
         run: |
           gcloud container clusters create ${{ env.clusterName2 }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
@@ -234,7 +234,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium in cluster1

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -64,10 +64,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName1: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-1
-  clusterName2: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
+  clusterName1: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-1
+  clusterName2: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
   zone: us-west2-a
-  firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
+  firewallRuleName: datadog-${{ github.event.repository.name }}-${{ github.run_id }}-rule
   cilium_cli_version: v0.10.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -139,15 +139,15 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          CILIUM_INSTALL_DEFAULTS="--agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+          CILIUM_INSTALL_DEFAULTS="--agent-image=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
+            --operator-image=public.ecr.aws/b1o7r7e0/cilium/datadog/operator-generic-ci \
             --version=${SHA} \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none"
-          HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+          HUBBLE_ENABLE_DEFAULTS="--relay-image=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --relay-version=${SHA}"
-          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \
+          CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=public.ecr.aws/b1o7r7e0/cilium/datadog/clustermesh-apiserver-ci \
             --apiserver-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
@@ -187,7 +187,7 @@ jobs:
       - name: Create GKE cluster 1
         run: |
           gcloud container clusters create ${{ env.clusterName1 }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
@@ -201,7 +201,7 @@ jobs:
       - name: Create GKE cluster 2
         run: |
           gcloud container clusters create ${{ env.clusterName2 }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=datadog-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
@@ -236,7 +236,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium in cluster1

--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -168,7 +168,7 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
-          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/cilium-ci/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
 
       - name: Run tests
         run: |

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -168,7 +168,7 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
-          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/cilium-ci/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
 
       - name: Run tests
         run: |

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -170,7 +170,7 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
-          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/cilium-ci/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
 
       - name: Run tests
         run: |

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -88,7 +88,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/${image}/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/${image}/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install cilium chart
@@ -98,16 +98,16 @@ jobs:
             --set nodeinit.enabled=true \
             --set kubeProxyReplacement=strict \
             --set ipam.mode=kubernetes \
-            --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
+            --set image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
             --set image.tag=${{ steps.vars.outputs.tag }} \
             --set image.pullPolicy=IfNotPresent \
             --set image.useDigest=false \
             --set hubble.relay.enabled=true \
-            --set hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+            --set hubble.relay.image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
             --set hubble.relay.image.tag=${{ steps.vars.outputs.tag }} \
             --set hubble.relay.image.pullPolicy=IfNotPresent \
             --set hubble.relay.image.useDigest=false \
-            --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
+            --set operator.image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/operator \
             --set operator.image.suffix=-ci \
             --set operator.image.tag=${{ steps.vars.outputs.tag }} \
             --set operator.image.pullPolicy=IfNotPresent \

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -133,7 +133,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/${image}/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/datadog/${image}/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install cilium chart
@@ -149,16 +149,16 @@ jobs:
              --set hostPort.enabled=true \
              --set bpf.masquerade=false \
              --set ipam.mode=kubernetes \
-             --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
+             --set image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/cilium-ci \
              --set image.tag=${{ steps.vars.outputs.tag }} \
              --set image.pullPolicy=IfNotPresent \
              --set image.useDigest=false \
              --set hubble.relay.enabled=true \
-             --set hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+             --set hubble.relay.image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/hubble-relay-ci \
              --set hubble.relay.image.tag=${{ steps.vars.outputs.tag }} \
              --set hubble.relay.image.pullPolicy=IfNotPresent \
              --set hubble.relay.image.useDigest=false \
-             --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
+             --set operator.image.repository=public.ecr.aws/b1o7r7e0/cilium/datadog/operator \
              --set operator.image.suffix=-ci \
              --set operator.image.tag=${{ steps.vars.outputs.tag }} \
              --set operator.image.pullPolicy=IfNotPresent \

--- a/test/eni/IPRelease.go
+++ b/test/eni/IPRelease.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020-2021 Authors of Cilium
+
+package eniTest
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cilium/cilium/pkg/logging"
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+	"github.com/cilium/cilium/test/nodegroups"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/check.v1"
+)
+
+func getAllocatedIPsOnNode(kubectl *helpers.Kubectl, nodeName string) (int, error) {
+	cn := kubectl.GetCiliumNode(nodeName)
+	if cn == nil {
+		return 0, fmt.Errorf("Unable to fetch cn %s", nodeName)
+	}
+	return len(cn.Spec.IPAM.Pool), nil
+}
+
+func hasRequiredIPsAllocated(kubectl *helpers.Kubectl, nodeName string, n int) func() bool {
+	return func() bool {
+		cn := kubectl.GetCiliumNode(nodeName)
+		if cn == nil {
+			return false
+		}
+		return len(cn.Spec.IPAM.Pool) == n
+	}
+}
+
+func hasRequiredIPBuffer(kubectl *helpers.Kubectl, nodeName string, n int) func() bool {
+	return func() bool {
+		cn := kubectl.GetCiliumNode(nodeName)
+		if cn == nil {
+			return false
+		}
+		return (len(cn.Spec.IPAM.Pool) - len(cn.Status.IPAM.Used)) == n
+	}
+}
+
+func hasIPsInHandshake(kubectl *helpers.Kubectl, nodeName string) func() bool {
+	return func() bool {
+		cn := kubectl.GetCiliumNode(nodeName)
+		if cn == nil {
+			return false
+		}
+		return len(cn.Status.IPAM.ReleaseIPs) > 0
+	}
+}
+
+func hasNoIPsInHandshake(kubectl *helpers.Kubectl, nodeName string) func() bool {
+	return func() bool {
+		cn := kubectl.GetCiliumNode(nodeName)
+		if cn == nil {
+			return false
+		}
+		return len(cn.Status.IPAM.ReleaseIPs) == 0
+	}
+}
+
+var _ = Describe("EniIPReleaseHandshakeTest", func() {
+	var (
+		kubectl           *helpers.Kubectl
+		ciliumCli         *helpers.CiliumCli
+		deploymentManager *helpers.DeploymentManager
+		releaseTestNs     = "cilium-integration-tests"
+	)
+
+	BeforeAll(func() {
+		var log = logging.DefaultLogger
+		var logger = logrus.NewEntry(log)
+		kubectl = helpers.CreateKubectl("", logger)
+		ciliumCli = helpers.CreateCiliumCli(logger)
+		deploymentManager = helpers.NewDeploymentManager()
+		deploymentManager.SetKubectl(kubectl)
+	})
+
+	AfterAll(func() {
+		deploymentManager.DeleteAll()
+	})
+
+	AfterFailed(func() {
+		kubectl.CiliumReport("cilium status", "cilium endpoint list")
+	})
+
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	It("Test IP release abort", func() {
+		By("Enabling aws excess IP release feature and restarting cilium operator")
+		err := ciliumCli.UpdateCiliumConfig("aws-excess-ip-release", "true", false)
+		Expect(err).NotTo(Equal(check.IsNil))
+
+		// Workaround till cilium-cli supports restarting operator based on config change
+		err = kubectl.RestartOperator()
+		Expect(err).NotTo(Equal(check.IsNil))
+
+		By("Create nodegroup to deploy tests on")
+		ng := nodegroups.EksNodegroup{NodePool: nodegroups.NodePool{
+			Name:          "ip-release",
+			ClusterName:   os.Getenv("clusterName"),
+			InstanceTypes: []string{"t3.medium", "t3a.medium"},
+			Region:        os.Getenv("region"),
+			NumNodes:      1,
+			NodeTaint:     "ip-release",
+			Executor:      helpers.CreateLocalExecutor([]string{}),
+			Kubectl:       kubectl,
+		}}
+		err = ng.CreateNodePool()
+		Expect(err).To(Equal(check.IsNil))
+
+		By("Creating a deployment to pick a node to test on")
+		configFile := "nginx-with-tolerations.yaml"
+		labelSelector := "zgroup=http-server"
+		tmpl := helpers.ManifestGet(kubectl.BasePath(), "http-deployment-node-toleration.yaml.tmpl")
+		helpers.RenderTemplateWithData(tmpl, configFile, struct{ NodeTaint string }{NodeTaint: "ip-release"})
+
+		res := kubectl.Exec(fmt.Sprintf("kubectl -n %s apply -f %s", releaseTestNs, configFile))
+		if !res.WasSuccessful() {
+			Failf("error creating test workload %v", err.Error())
+		}
+		kubectl.WaitforNPodsRunning(releaseTestNs, "-l "+labelSelector, 2, 10*time.Minute)
+
+		By("Fetching cilium node for test pods")
+		data, err := kubectl.GetPodsNodes(releaseTestNs, labelSelector)
+		if err != nil {
+			Fail(err.Error())
+		}
+		var nodeName string
+		for _, v := range data {
+			nodeName = v
+			break
+		}
+
+		cn := kubectl.GetCiliumNode(nodeName)
+		Expect(cn).NotTo(Equal(check.IsNil))
+		totalBuffer := cn.Spec.IPAM.PreAllocate + cn.Spec.IPAM.MaxAboveWatermark
+
+		initialAllocCnt, err := getAllocatedIPsOnNode(kubectl, nodeName)
+		Expect(err).NotTo(Equal(check.IsNil))
+
+		By("Scaling replicas by 2")
+		res = kubectl.Exec(fmt.Sprintf("kubectl -n %s scale deploy %s --replicas=%v", releaseTestNs, "http-server", 4))
+		if !res.WasSuccessful() {
+			Failf("Error while scaling replicas %v", err.Error())
+		}
+
+		By("Wait for new pods to start up")
+		kubectl.WaitforNPodsRunning(releaseTestNs, "-l "+labelSelector, 4, helpers.HelperTimeout)
+
+		By("Wait for new IPs to be allocated")
+		err = helpers.WithTimeout(hasRequiredIPBuffer(kubectl, nodeName, totalBuffer), "Timeout while waiting for IPs to be released from pool",
+			&helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for IPs to be released from pool")
+
+		By("Scale back by 2 to create excess")
+		res = kubectl.Exec(fmt.Sprintf("kubectl -n %s scale deploy %s --replicas=%v", releaseTestNs, "http-server", 2))
+		if !res.WasSuccessful() {
+			Failf("Error while scaling replicas %v", err.Error())
+		}
+
+		By("Wait for IPs to be marked for release")
+		err = helpers.WithTimeout(hasIPsInHandshake(kubectl, nodeName), "Timeout while waiting for release IPs to be marked",
+			&helpers.TimeoutConfig{Timeout: 5 * time.Minute})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for release IPs to be marked")
+
+		By("Wait for IPs to be released from the pool")
+		err = helpers.WithTimeout(hasRequiredIPsAllocated(kubectl, nodeName, initialAllocCnt), "Timeout while waiting for IPs to be released from pool",
+			&helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for IPs to be released from pool")
+
+		By("Wait for entries to be cleared from release status")
+		err = helpers.WithTimeout(hasNoIPsInHandshake(kubectl, nodeName), "Timeout while waiting for entries to be cleared from release status",
+			&helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for entries to be cleared from release status")
+	})
+
+})

--- a/test/helpers/cilium-cli.go
+++ b/test/helpers/cilium-cli.go
@@ -1,0 +1,43 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/test/config"
+)
+
+const (
+	CiliumCliCmd = "cilium"
+)
+
+type CiliumCli struct {
+	executor Executor
+	log      *logrus.Entry
+}
+
+func CreateCiliumCli(log *logrus.Entry) (c *CiliumCli) {
+	var environ []string
+	if config.CiliumTestConfig.PassCLIEnvironment {
+		environ = append(environ, os.Environ()...)
+	}
+	environ = append(environ, "KUBECONFIG="+config.CiliumTestConfig.Kubeconfig)
+	environ = append(environ, fmt.Sprintf("PATH=%s:%s", GetKubectlPath(), os.Getenv("PATH")))
+
+	c = &CiliumCli{
+		executor: CreateLocalExecutor(environ),
+		log:      log,
+	}
+	return c
+}
+
+func (c *CiliumCli) UpdateCiliumConfig(key string, val string, restart bool) error {
+	res := c.executor.ExecShort(fmt.Sprintf("%s config set --restart=%v %s %s", CiliumCliCmd, restart, key, val))
+
+	if !res.WasSuccessful() {
+		return fmt.Errorf("unable to update config with error %s", res.OutputPrettyPrint())
+	}
+	return nil
+}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -853,6 +854,40 @@ func (kub *Kubectl) GetCNP(namespace string, cnp string) *cnpv2.CiliumNetworkPol
 		return nil
 	}
 	return &result
+}
+
+// GetCiliumNode retrieves the output of `kubectl get cnp` in the given namespace for
+// the given CNP and return a CNP struct. If the CNP does not exists or cannot
+// unmarshal the Json output will return nil.
+func (kub *Kubectl) GetCiliumNode(ciliumNode string) *cnpv2.CiliumNode {
+	log := kub.Logger().WithFields(logrus.Fields{
+		"fn":  "GetCiliumNode",
+		"cnp": ciliumNode,
+	})
+	res := kub.Get("''", fmt.Sprintf("cn %s", ciliumNode))
+	if !res.WasSuccessful() {
+		log.WithField("error", res.CombineOutput()).Info("cannot get CN")
+		return nil
+	}
+	var result cnpv2.CiliumNode
+	err := res.Unmarshal(&result)
+	if err != nil {
+		log.WithError(err).Errorf("cannot unmarshal CN output")
+		return nil
+	}
+	return &result
+}
+
+func (kub *Kubectl) RestartOperator() error {
+	res := kub.DeleteResource("pod", "-n "+KubeSystemNamespace+" -l "+CiliumOperatorLabel)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("cannot delete operator with error : %s", res.OutputPrettyPrint())
+	}
+	res = kub.Exec(fmt.Sprintf("%s wait --for=condition=ready pod -l %s --timeout=60s", KubectlCmd, CiliumOperatorLabel))
+	if !res.WasSuccessful() {
+		return fmt.Errorf("timeout while waiting for operator to be ready")
+	}
+	return nil
 }
 
 func (kub *Kubectl) WaitForCRDCount(filter string, count int, timeout time.Duration) error {
@@ -4583,8 +4618,8 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 		rcVersion = fmt.Sprintf("v%s.0", GetCurrentK8SEnv())
 	}
 	res = kub.Exec(
-		fmt.Sprintf("curl --output %s https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
-			path, rcVersion, path))
+		fmt.Sprintf("curl --output %s https://storage.googleapis.com/kubernetes-release/release/%s/bin/%s/%s/kubectl && chmod +x %s",
+			path, rcVersion, runtime.GOOS, runtime.GOARCH, path))
 	if !res.WasSuccessful() {
 		return fmt.Errorf("failed to download kubectl")
 	}

--- a/test/helpers/scope.go
+++ b/test/helpers/scope.go
@@ -30,6 +30,8 @@ func GetScope() (string, error) {
 	case strings.Contains(focusString, "nightly"):
 		// Nightly tests run in a Kubernetes environment.
 		return K8s, nil
+	case strings.Contains(focusString, "eni"):
+		return "Eni", nil
 	default:
 		return "", errors.New("Scope cannot be set")
 	}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -85,6 +85,23 @@ func RenderTemplate(tmplt string) (*bytes.Buffer, error) {
 	return content, nil
 }
 
+func RenderTemplateWithData(sourcePath string, destPath string, data interface{}) error {
+	tmpl, err := template.ParseFiles(sourcePath)
+	if err != nil {
+		return fmt.Errorf("error while parsing template : %v", err.Error())
+	}
+	f, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("error while opening destination file : %v", err.Error())
+	}
+	defer f.Close()
+	err = tmpl.Execute(f, data)
+	if err != nil {
+		return fmt.Errorf("error while rendering template : %v", err.Error())
+	}
+	return nil
+}
+
 // TimeoutConfig represents the configuration for the timeout of a command.
 type TimeoutConfig struct {
 	Ticker  time.Duration // Check interval

--- a/test/k8sT/manifests/eks-nodegroup.yaml.tmpl
+++ b/test/k8sT/manifests/eks-nodegroup.yaml.tmpl
@@ -1,0 +1,23 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: {{ .ClusterName }}
+  region: {{ .Region }}
+managedNodeGroups:
+  - name: {{ .Name }}
+    instanceTypes:
+    {{range .InstanceTypes}}
+    - {{ . }}
+    {{end}}
+    desiredCapacity: {{ .NumNodes }}
+    spot: true
+    privateNetworking: true
+    volumeType: "gp3"
+    volumeSize: 10
+    taints:
+      - key: "node.cilium.io/agent-not-ready"
+        value: "true"
+        effect: "NoSchedule"
+      - key: {{ .NodeTaint }}
+        value: "true"
+        effect: "NoSchedule"

--- a/test/k8sT/manifests/http-deployment-node-toleration.yaml.tmpl
+++ b/test/k8sT/manifests/http-deployment-node-toleration.yaml.tmpl
@@ -1,0 +1,24 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: http-server
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+        zgroup: http-server
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/library/nginx:1.19.4
+          ports:
+            - containerPort: 80
+      tolerations:
+        - key: {{ .NodeTaint }}
+          operator: "Exists"
+          effect: "NoSchedule"

--- a/test/nodegroups/nodegroups.go
+++ b/test/nodegroups/nodegroups.go
@@ -1,0 +1,66 @@
+package nodegroups
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/test/helpers"
+)
+
+const (
+	EksCliCmd = "eksctl"
+	AksCliCmd = "az"
+	GKECliCmd = "gcloud"
+)
+
+type NodePool struct {
+	Name          string
+	ClusterName   string
+	InstanceTypes []string
+	Region        string
+	// Number of nodes for fixed size node pools
+	NumNodes int
+	// Min number of nodes in the nodepool
+	MinNodes int
+	// Taint to be added to the nodes created in this nodepool
+	NodeTaint string
+	Executor  *helpers.LocalExecutor
+	Kubectl   *helpers.Kubectl
+}
+
+type EksNodegroup struct {
+	NodePool
+}
+
+type NodePoolImpl interface {
+	CreateNodePool() error
+	DeleteNodePool() error
+	ScaleNodePool() error
+}
+
+func (e *EksNodegroup) CreateNodePool() error {
+	configFile := e.Name + ".yaml"
+	tmpl := helpers.ManifestGet(e.Kubectl.BasePath(), "eks-nodegroup.yaml.tmpl")
+	err := helpers.RenderTemplateWithData(tmpl, configFile, e.NodePool)
+	if err != nil {
+		return err
+	}
+	cmd := fmt.Sprintf("%s create nodegroup --config-file=%s", EksCliCmd, configFile)
+	res := e.Executor.ExecMiddle(cmd)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("unable to create eks nodegroup : %s", res.OutputPrettyPrint())
+	}
+	return nil
+}
+
+func (e *EksNodegroup) DeleteNodePool() error {
+	cmd := fmt.Sprintf("%s delete nodegroup --cluster=%s -n=%s", EksCliCmd, e.ClusterName, e.Name)
+	res := e.Executor.ExecMiddle(cmd)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("unable to create eks nodegroup : %s", res.OutputPrettyPrint())
+	}
+	return nil
+}
+
+func (e *EksNodegroup) ScaleNodePool() error {
+	return fmt.Errorf("scaling nodegroup is not implemented yet")
+}

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -8,6 +8,7 @@ package ciliumTest
 
 import (
 	// test sources
+	_ "github.com/cilium/cilium/test/eni"
 	_ "github.com/cilium/cilium/test/k8sT"
 	_ "github.com/cilium/cilium/test/runtime"
 )


### PR DESCRIPTION
Currently there is no way to write e2e tests exclusive to a cloud provider.
This commit introduces a new focus group for ENI, which can be used to
house e2e tests for cloud provider specific features like AWS excess IP
release, ENI prefix delegation, etc. There are more features that aren't
currently tested e2e in CI and this focus group makes it easy to add them.
This commit also includes an e2e test for IP release.