### PR TITLE
Cherry-picks for v1.10-dd

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -115,6 +115,7 @@ cilium-agent [flags]
       --enable-session-affinity                              Enable support for service session affinity
       --enable-svc-source-range-check                        Enable check of service source ranges (currently, only for LoadBalancer) (default true)
       --enable-tracing                                       Enable tracing while determining policy (debugging)
+      --enable-unreachable-routes                            Add unreachable routes on pod deletion
       --enable-well-known-identities                         Enable well-known identities for known Kubernetes components (default true)
       --enable-wireguard                                     Enable wireguard
       --enable-xdp-prefilter                                 Enable XDP prefiltering

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -36,6 +36,7 @@ cilium-operator-aws [flags]
       --enable-metrics                            Enable Prometheus metrics
       --enable-wireguard                          Enable wireguard
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
+      --excess-ip-release-delay int               Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
       --gops-port int                             Port for gops server to listen on (default 9891)
   -h, --help                                      help for cilium-operator-aws
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -42,6 +42,7 @@ cilium-operator [flags]
       --enable-metrics                            Enable Prometheus metrics
       --enable-wireguard                          Enable wireguard
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
+      --excess-ip-release-delay int               Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
       --gops-port int                             Port for gops server to listen on (default 9891)
   -h, --help                                      help for cilium-operator
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -405,6 +405,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableTracing, false, "Enable tracing while determining policy (debugging)")
 	option.BindEnv(option.EnableTracing)
 
+	flags.Bool(option.EnableUnreachableRoutes, false, "Add unreachable routes on pod deletion")
+	option.BindEnv(option.EnableUnreachableRoutes)
+
 	flags.Bool(option.EnableWellKnownIdentities, defaults.EnableWellKnownIdentities, "Enable well-known identities for known Kubernetes components")
 	option.BindEnv(option.EnableWellKnownIdentities)
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -147,6 +147,10 @@ const (
 	// the number of API calls to AWS EC2 service.
 	AWSReleaseExcessIPs = "aws-release-excess-ips"
 
+	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
+	// Defaults to 180 secs
+	ExcessIPReleaseDelay = "excess-ip-release-delay"
+
 	// ENITags are the tags that will be added to every ENI created by the
 	// AWS ENI IPAM.
 	ENITags = "eni-tags"
@@ -337,6 +341,10 @@ type OperatorConfig struct {
 	// instancetype to adapter limit mapping.
 	UpdateEC2AdapterLimitViaAPI bool
 
+	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
+	// Defaults to 180 secs
+	ExcessIPReleaseDelay int
+
 	// EC2APIEndpoint is the custom API endpoint to use for the EC2 AWS service,
 	// e.g. "ec2-fips.us-west-1.amazonaws.com" to use a FIPS endpoint in the us-west-1 region.
 	EC2APIEndpoint string
@@ -412,6 +420,7 @@ func (c *OperatorConfig) Populate() {
 	c.AWSReleaseExcessIPs = viper.GetBool(AWSReleaseExcessIPs)
 	c.UpdateEC2AdapterLimitViaAPI = viper.GetBool(UpdateEC2AdapterLimitViaAPI)
 	c.EC2APIEndpoint = viper.GetString(EC2APIEndpoint)
+	c.ExcessIPReleaseDelay = viper.GetInt(ExcessIPReleaseDelay)
 
 	// Azure options
 

--- a/operator/provider_aws_flags.go
+++ b/operator/provider_aws_flags.go
@@ -39,6 +39,9 @@ func init() {
 	flags.Bool(operatorOption.AWSReleaseExcessIPs, false, "Enable releasing excess free IP addresses from AWS ENI.")
 	option.BindEnv(operatorOption.AWSReleaseExcessIPs)
 
+	flags.Int(operatorOption.ExcessIPReleaseDelay, 180, "Number of seconds operator would wait before it releases an IP previously marked as excess")
+	option.BindEnv(operatorOption.ExcessIPReleaseDelay)
+
 	flags.Var(option.NewNamedMapOptions(operatorOption.ENITags, &operatorOption.Config.ENITags, nil),
 		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
 	option.BindEnv(operatorOption.ENITags)

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -130,9 +131,17 @@ func (n *Node) PrepareIPRelease(excessIPs int, scopedLog *logrus.Entry) *ipam.Re
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
+	// Needed for selecting the same ENI to release IPs from
+	// when more than one ENI qualifies for release
+	eniIds := make([]string, 0, len(n.enis))
+	for k := range n.enis {
+		eniIds = append(eniIds, k)
+	}
+	sort.Strings(eniIds)
 	// Iterate over ENIs on this node, select the ENI with the most
 	// addresses available for release
-	for key, e := range n.enis {
+	for _, eniId := range eniIds {
+		e := n.enis[eniId]
 		scopedLog.WithFields(logrus.Fields{
 			fieldEniID:     e.ID,
 			"needIndex":    *n.k8sObj.Spec.ENI.FirstInterfaceIndex,
@@ -171,7 +180,7 @@ func (n *Node) PrepareIPRelease(excessIPs int, scopedLog *logrus.Entry) *ipam.Re
 		eniWithMoreFreeIPsFound := maxReleaseOnENI > len(r.IPsToRelease)
 		// Select the ENI with the most addresses available for release
 		if firstENIWithFreeIPFound || eniWithMoreFreeIPsFound {
-			r.InterfaceID = key
+			r.InterfaceID = eniId
 			r.PoolID = ipamTypes.PoolID(e.Subnet.ID)
 			r.IPsToRelease = freeIpsOnENI[:maxReleaseOnENI]
 		}

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	ec2mock "github.com/cilium/cilium/pkg/aws/ec2/mock"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/aws/types"
@@ -421,6 +422,8 @@ func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 
 	// Use 10 out of 10 IPs, PreAllocate 1 must kick in and allocate an additional IP
 	mngr.Update(updateCiliumNode(cn, 10, 10))
+	syncTime := instances.Resync(context.TODO())
+	mngr.Resync(context.TODO(), syncTime)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 	node = mngr.Get("node2")
 	c.Assert(node, check.Not(check.IsNil))
@@ -446,6 +449,7 @@ func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 // - MaxAboveWatermark 3
 // - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
+	operatorOption.Config.ExcessIPReleaseDelay = 2
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
@@ -507,8 +511,27 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	obj.Status.ENI.ENIs = eniNode.enis
 	eniNode.mutex.RUnlock()
 	node.UpdatedResource(obj)
+
+	// Excess timestamps should be registered after this
 	syncTime := instances.Resync(context.TODO())
 	mngr.Resync(context.TODO(), syncTime)
+
+	// Acknowledge release IPs after 3 secs
+	time.AfterFunc(3*time.Second, func() {
+		// Excess delay duration should have elapsed by now, trigger resync again.
+		// IPs should be marked as excess
+		syncTime := instances.Resync(context.TODO())
+		mngr.Resync(context.TODO(), syncTime)
+		time.Sleep(1 * time.Second)
+		node.PopulateIPReleaseStatus(obj)
+		// Fake acknowledge IPs for release like agent would.
+		testutils.FakeAcknowledgeReleaseIps(obj)
+		node.UpdatedResource(obj)
+		// Resync one more time to process acknowledgements.
+		syncTime = instances.Resync(context.TODO())
+		mngr.Resync(context.TODO(), syncTime)
+	})
+
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
 	node = mngr.Get("node3")
 	c.Assert(node, check.Not(check.IsNil))
@@ -550,6 +573,8 @@ func (e *ENISuite) TestNodeManagerExceedENICapacity(c *check.C) {
 	// assigned the remaining 3 that the t2.xlarge instance type supports
 	// (3x15 - 3 = 42 max)
 	mngr.Update(updateCiliumNode(cn, 42, 40))
+	syncTime := instances.Resync(context.TODO())
+	mngr.Resync(context.TODO(), syncTime)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 
 	node = mngr.Get("node2")

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -220,13 +220,20 @@ func Delete(ip net.IP, compat bool) error {
 		scopedLog.WithField(logfields.Rule, egress).Debug("Deleted egress rule")
 	}
 
-	// Mark IP as unreachable to avoid triggering rp_filter after endpoint deletion for new packets to pod IP
-	if err := netlink.RouteReplace(&netlink.Route{
-		Dst:   &ipWithMask,
-		Table: route.MainTable,
-		Type:  unix.RTN_UNREACHABLE,
-	}); err != nil {
-		return fmt.Errorf("unable to add unreachable route for ip %s: %w", ipWithMask.String(), err)
+	if option.Config.EnableUnreachableRoutes {
+		// Replace route to old IP with an unreachable route. This will
+		//   - trigger ICMP error messages for clients attempting to connect to the stale IP
+		//   - avoid hitting rp_filter and getting Martian packet warning
+		// When the IP is reused, the unreachable route will be replaced to target the new pod veth
+		// In CRD-based IPAM, when an IP is unassigned from the CiliumNode, we delete this route
+		// to avoid blackholing traffic to this IP if it gets reassigned to another node
+		if err := netlink.RouteReplace(&netlink.Route{
+			Dst:   &ipWithMask,
+			Table: route.MainTable,
+			Type:  unix.RTN_UNREACHABLE,
+		}); err != nil {
+			return fmt.Errorf("unable to add unreachable route for ip %s: %w", ipWithMask.String(), err)
+		}
 	}
 
 	return nil

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -220,6 +220,15 @@ func Delete(ip net.IP, compat bool) error {
 		scopedLog.WithField(logfields.Rule, egress).Debug("Deleted egress rule")
 	}
 
+	// Mark IP as unreachable to avoid triggering rp_filter after endpoint deletion for new packets to pod IP
+	if err := netlink.RouteReplace(&netlink.Route{
+		Dst:   &ipWithMask,
+		Table: route.MainTable,
+		Type:  unix.RTN_UNREACHABLE,
+	}); err != nil {
+		return fmt.Errorf("unable to add unreachable route for ip %s: %w", ipWithMask.String(), err)
+	}
+
 	return nil
 }
 

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -139,12 +139,19 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, k8sEventReg 
 				defer func() { k8sEventReg.K8sEventReceived("CiliumNode", "update", valid, equal) }()
 				if oldNode, ok := oldObj.(*ciliumv2.CiliumNode); ok {
 					if newNode, ok := newObj.(*ciliumv2.CiliumNode); ok {
+						valid = true
+						newNode = newNode.DeepCopy()
 						if oldNode.DeepEqual(newNode) {
+							// The UpdateStatus call in refreshNode requires an up-to-date
+							// CiliumNode.ObjectMeta.ResourceVersion. Therefore, we store the most
+							// recent version here even if the nodes are equal, because
+							// CiliumNode.DeepEqual will consider two nodes to be equal even if
+							// their resource version differs.
+							store.setOwnNodeWithoutPoolUpdate(newNode)
 							equal = true
 							return
 						}
-						valid = true
-						store.updateLocalNodeResource(newNode.DeepCopy())
+						store.updateLocalNodeResource(newNode)
 						k8sEventReg.K8sEventProcessed("CiliumNode", "update", true)
 					} else {
 						log.Warningf("Unknown CiliumNode object type %T received: %+v", oldNode, oldNode)
@@ -334,6 +341,14 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 			}
 		}
 	}
+}
+
+// setOwnNodeWithoutPoolUpdate overwrites the local node copy (e.g. to update
+// its resourceVersion) without updating the available IP pool.
+func (n *nodeStore) setOwnNodeWithoutPoolUpdate(node *ciliumv2.CiliumNode) {
+	n.mutex.Lock()
+	n.ownNode = node
+	n.mutex.Unlock()
 }
 
 // refreshNodeTrigger is called to refresh the custom resource after taking the

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -23,8 +23,6 @@ import (
 	"sync"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	alibabaCloud "github.com/cilium/cilium/pkg/alibabacloud/utils"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/ip"
@@ -41,6 +39,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -272,7 +271,11 @@ func (n *nodeStore) hasMinimumIPsInPool() (minimumReached bool, required, numAva
 	}
 
 	if n.ownNode.Spec.IPAM.Pool != nil {
-		numAvailable = len(n.ownNode.Spec.IPAM.Pool)
+		for ip := range n.ownNode.Spec.IPAM.Pool {
+			if !n.isIPInReleaseHandshake(ip) {
+				numAvailable++
+			}
+		}
 		if len(n.ownNode.Spec.IPAM.Pool) >= required {
 			minimumReached = true
 		}
@@ -340,6 +343,50 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 				}
 			}
 		}
+	}
+
+	releaseUpstreamSyncNeeded := false
+	// ACK or NACK IPs marked for release by the operator
+	for ip, status := range n.ownNode.Status.IPAM.ReleaseIPs {
+		if status != ipamOption.IPAMMarkForRelease || n.ownNode.Spec.IPAM.Pool == nil {
+			continue
+		}
+		// NACK the IP, if this node doesn't own the IP
+		if _, ok := n.ownNode.Spec.IPAM.Pool[ip]; !ok {
+			n.ownNode.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMDoNotRelease
+			continue
+		}
+		// Retrieve the appropriate allocator
+		var allocator *crdAllocator
+		var ipFamily Family
+		if ipAddr := net.ParseIP(ip); ipAddr != nil {
+			ipFamily = DeriveFamily(ipAddr)
+		}
+		if ipFamily == "" {
+			continue
+		}
+		for _, a := range n.allocators {
+			if a.family == ipFamily {
+				allocator = a
+			}
+		}
+		if allocator == nil {
+			continue
+		}
+
+		allocator.mutex.Lock()
+		if _, ok := allocator.allocated[ip]; ok {
+			// IP still in use, update the operator to stop releasing the IP.
+			n.ownNode.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMDoNotRelease
+		} else {
+			n.ownNode.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMReadyForRelease
+		}
+		allocator.mutex.Unlock()
+		releaseUpstreamSyncNeeded = true
+	}
+
+	if releaseUpstreamSyncNeeded {
+		n.refreshTrigger.TriggerWithReason("excess IP release")
 	}
 }
 
@@ -415,12 +462,29 @@ func (n *nodeStore) allocate(ip net.IP) (*ipamTypes.AllocationIP, error) {
 		return nil, fmt.Errorf("No IPs available")
 	}
 
+	if n.isIPInReleaseHandshake(ip.String()) {
+		return nil, fmt.Errorf("IP not available, marked or ready for release")
+	}
+
 	ipInfo, ok := n.ownNode.Spec.IPAM.Pool[ip.String()]
 	if !ok {
 		return nil, NewIPNotAvailableInPoolError(ip)
 	}
 
 	return &ipInfo, nil
+}
+
+// isIPInReleaseHandshake validates if a given IP is currently in the process of being released
+func (n *nodeStore) isIPInReleaseHandshake(ip string) bool {
+	if n.ownNode.Status.IPAM.ReleaseIPs == nil {
+		return false
+	}
+	if status, ok := n.ownNode.Status.IPAM.ReleaseIPs[ip]; ok {
+		if status == ipamOption.IPAMMarkForRelease || status == ipamOption.IPAMReadyForRelease {
+			return true
+		}
+	}
+	return false
 }
 
 // allocateNext allocates the next available IP or returns an error
@@ -436,6 +500,10 @@ func (n *nodeStore) allocateNext(allocated ipamTypes.AllocationMap, family Famil
 	// optimized
 	for ip, ipInfo := range n.ownNode.Spec.IPAM.Pool {
 		if _, ok := allocated[ip]; !ok {
+
+			if n.isIPInReleaseHandshake(ip) {
+				continue // IP not available
+			}
 			parsedIP := net.ParseIP(ip)
 			if parsedIP == nil {
 				log.WithFields(logrus.Fields{

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -16,6 +16,7 @@ package ipam
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -38,6 +39,8 @@ import (
 	"github.com/cilium/cilium/pkg/trigger"
 
 	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -360,6 +363,25 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 				// Remove entry from release-ips only when it is removed from .spec.ipam.pool as well
 				delete(n.ownNode.Status.IPAM.ReleaseIPs, ip)
 				releaseUpstreamSyncNeeded = true
+
+				// Remove the unreachable route for this IP
+				parsedIP := net.ParseIP(ip)
+				if parsedIP == nil {
+					// Unable to parse IP, no point in trying to remove the route
+					log.Warningf("Unable to parse IP %s", ip)
+					continue
+				}
+
+				err := netlink.RouteDel(&netlink.Route{
+					Dst:   &net.IPNet{IP: parsedIP, Mask: net.CIDRMask(32, 32)},
+					Table: unix.RT_TABLE_MAIN,
+					Type:  unix.RTN_UNREACHABLE,
+				})
+				if err != nil && !errors.Is(err, unix.ESRCH) {
+					// We ignore ESRCH, as it means the entry was already deleted
+					log.WithError(err).Warningf("Unable to delete unreachable route for IP %s", ip)
+					continue
+				}
 			} else if status == ipamOption.IPAMMarkForRelease {
 				// NACK the IP, if this node doesn't own the IP
 				n.ownNode.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMDoNotRelease

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -351,17 +351,26 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 		if n.ownNode.Spec.IPAM.Pool == nil {
 			continue
 		}
+		// Ignore states that agent previously responded to.
 		if status == ipamOption.IPAMReadyForRelease || status == ipamOption.IPAMDoNotRelease {
 			continue
 		}
 		if _, ok := n.ownNode.Spec.IPAM.Pool[ip]; !ok {
 			if status == ipamOption.IPAMReleased {
-				// Remove entry from release-ips only when its removed the .spec.ipam.pool
+				// Remove entry from release-ips only when it is removed from .spec.ipam.pool as well
 				delete(n.ownNode.Status.IPAM.ReleaseIPs, ip)
+				releaseUpstreamSyncNeeded = true
 			} else if status == ipamOption.IPAMMarkForRelease {
 				// NACK the IP, if this node doesn't own the IP
 				n.ownNode.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMDoNotRelease
+				releaseUpstreamSyncNeeded = true
 			}
+			continue
+		}
+
+		// Ignore all other states, transition to do-not-release and ready-for-release are allowed only from
+		// marked-for-release
+		if status != ipamOption.IPAMMarkForRelease {
 			continue
 		}
 		// Retrieve the appropriate allocator
@@ -381,7 +390,6 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 		if allocator == nil {
 			continue
 		}
-
 		allocator.mutex.Lock()
 		if _, ok := allocator.allocated[ip]; ok {
 			// IP still in use, update the operator to stop releasing the IP.

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -348,12 +348,20 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 	releaseUpstreamSyncNeeded := false
 	// ACK or NACK IPs marked for release by the operator
 	for ip, status := range n.ownNode.Status.IPAM.ReleaseIPs {
-		if status != ipamOption.IPAMMarkForRelease || n.ownNode.Spec.IPAM.Pool == nil {
+		if n.ownNode.Spec.IPAM.Pool == nil {
 			continue
 		}
-		// NACK the IP, if this node doesn't own the IP
+		if status == ipamOption.IPAMReadyForRelease || status == ipamOption.IPAMDoNotRelease {
+			continue
+		}
 		if _, ok := n.ownNode.Spec.IPAM.Pool[ip]; !ok {
-			n.ownNode.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMDoNotRelease
+			if status == ipamOption.IPAMReleased {
+				// Remove entry from release-ips only when its removed the .spec.ipam.pool
+				delete(n.ownNode.Status.IPAM.ReleaseIPs, ip)
+			} else if status == ipamOption.IPAMMarkForRelease {
+				// NACK the IP, if this node doesn't own the IP
+				n.ownNode.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMDoNotRelease
+			}
 			continue
 		}
 		// Retrieve the appropriate allocator
@@ -480,7 +488,7 @@ func (n *nodeStore) isIPInReleaseHandshake(ip string) bool {
 		return false
 	}
 	if status, ok := n.ownNode.Status.IPAM.ReleaseIPs[ip]; ok {
-		if status == ipamOption.IPAMMarkForRelease || status == ipamOption.IPAMReadyForRelease {
+		if status == ipamOption.IPAMMarkForRelease || status == ipamOption.IPAMReadyForRelease || status == ipamOption.IPAMReleased {
 			return true
 		}
 	}

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -390,14 +390,22 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 		if allocator == nil {
 			continue
 		}
+
+		// Some functions like crdAllocator.Allocate() acquire lock on allocator first and then on nodeStore.
+		// So release nodestore lock before acquiring allocator lock to avoid potential deadlocks from inconsistent
+		// lock ordering.
+		n.mutex.Unlock()
 		allocator.mutex.Lock()
-		if _, ok := allocator.allocated[ip]; ok {
+		_, ok := allocator.allocated[ip]
+		allocator.mutex.Unlock()
+		n.mutex.Lock()
+
+		if ok {
 			// IP still in use, update the operator to stop releasing the IP.
 			n.ownNode.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMDoNotRelease
 		} else {
 			n.ownNode.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMReadyForRelease
 		}
-		allocator.mutex.Unlock()
 		releaseUpstreamSyncNeeded = true
 	}
 

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -365,22 +365,24 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 				releaseUpstreamSyncNeeded = true
 
 				// Remove the unreachable route for this IP
-				parsedIP := net.ParseIP(ip)
-				if parsedIP == nil {
-					// Unable to parse IP, no point in trying to remove the route
-					log.Warningf("Unable to parse IP %s", ip)
-					continue
-				}
+				if n.conf.UnreachableRoutesEnabled() {
+					parsedIP := net.ParseIP(ip)
+					if parsedIP == nil {
+						// Unable to parse IP, no point in trying to remove the route
+						log.Warningf("Unable to parse IP %s", ip)
+						continue
+					}
 
-				err := netlink.RouteDel(&netlink.Route{
-					Dst:   &net.IPNet{IP: parsedIP, Mask: net.CIDRMask(32, 32)},
-					Table: unix.RT_TABLE_MAIN,
-					Type:  unix.RTN_UNREACHABLE,
-				})
-				if err != nil && !errors.Is(err, unix.ESRCH) {
-					// We ignore ESRCH, as it means the entry was already deleted
-					log.WithError(err).Warningf("Unable to delete unreachable route for IP %s", ip)
-					continue
+					err := netlink.RouteDel(&netlink.Route{
+						Dst:   &net.IPNet{IP: parsedIP, Mask: net.CIDRMask(32, 32)},
+						Table: unix.RT_TABLE_MAIN,
+						Type:  unix.RTN_UNREACHABLE,
+					})
+					if err != nil && !errors.Is(err, unix.ESRCH) {
+						// We ignore ESRCH, as it means the entry was already deleted
+						log.WithError(err).Warningf("Unable to delete unreachable route for IP %s", ip)
+						continue
+					}
 				}
 			} else if status == ipamOption.IPAMMarkForRelease {
 				// NACK the IP, if this node doesn't own the IP

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -66,6 +66,7 @@ type testConfigurationCRD struct{}
 func (t *testConfigurationCRD) IPv4Enabled() bool                        { return true }
 func (t *testConfigurationCRD) IPv6Enabled() bool                        { return false }
 func (t *testConfigurationCRD) HealthCheckingEnabled() bool              { return true }
+func (t *testConfigurationCRD) UnreachableRoutesEnabled() bool           { return false }
 func (t *testConfigurationCRD) IPAMMode() string                         { return ipamOption.IPAMCRD }
 func (t *testConfigurationCRD) BlacklistConflictingRoutesEnabled() bool  { return false }
 func (t *testConfigurationCRD) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -8,10 +8,21 @@ package ipam
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/addressing"
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/datapath/fake"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	"github.com/cilium/cilium/pkg/trigger"
 
 	"github.com/stretchr/testify/assert"
+	. "gopkg.in/check.v1"
 )
 
 func TestIPNotAvailableInPoolError(t *testing.T) {
@@ -48,4 +59,72 @@ func TestIPNotAvailableInPoolError(t *testing.T) {
 	err2 = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
 	assert.NotEqual(t, err, err2)
 	assert.False(t, errors.Is(err, err2))
+}
+
+type testConfigurationCRD struct{}
+
+func (t *testConfigurationCRD) IPv4Enabled() bool                        { return true }
+func (t *testConfigurationCRD) IPv6Enabled() bool                        { return false }
+func (t *testConfigurationCRD) HealthCheckingEnabled() bool              { return true }
+func (t *testConfigurationCRD) IPAMMode() string                         { return ipamOption.IPAMCRD }
+func (t *testConfigurationCRD) BlacklistConflictingRoutesEnabled() bool  { return false }
+func (t *testConfigurationCRD) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}
+func (t *testConfigurationCRD) GetIPv4NativeRoutingCIDR() *cidr.CIDR     { return nil }
+func (t *testConfigurationCRD) IPv4NativeRoutingCIDR() *cidr.CIDR        { return nil }
+
+func newFakeNodeStore(conf Configuration, c *C) *nodeStore {
+	t, err := trigger.NewTrigger(trigger.Parameters{
+		Name:        "fake-crd-allocator-node-refresher",
+		MinInterval: 3 * time.Second,
+		TriggerFunc: func(reasons []string) {},
+	})
+	if err != nil {
+		log.WithError(err).Fatal("Unable to initialize CiliumNode synchronization trigger")
+	}
+	store := &nodeStore{
+		allocators:         []*crdAllocator{},
+		allocationPoolSize: map[Family]int{},
+		conf:               conf,
+		refreshTrigger:     t,
+	}
+	return store
+}
+
+func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
+	cn := newCiliumNode("node1", 4, 4, 0)
+	dummyResource := ipamTypes.AllocationIP{Resource: "foo"}
+	for i := 1; i <= 4; i++ {
+		cn.Spec.IPAM.Pool[fmt.Sprintf("1.1.1.%d", i)] = dummyResource
+	}
+
+	fakeAddressing := fake.NewNodeAddressing()
+	conf := &testConfigurationCRD{}
+	initNodeStore.Do(func() {
+		sharedNodeStore = newFakeNodeStore(conf, c)
+		sharedNodeStore.ownNode = cn
+	})
+	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, &ownerMock{}, &mtuMock)
+	sharedNodeStore.updateLocalNodeResource(cn)
+
+	// Allocate the first 3 IPs
+	for i := 1; i <= 3; i++ {
+		epipv4, _ := addressing.NewCiliumIPv4(fmt.Sprintf("1.1.1.%d", i))
+		_, err := ipam.IPv4Allocator.Allocate(epipv4.IP(), fmt.Sprintf("test%d", i))
+		c.Assert(err, IsNil)
+	}
+
+	// Update 1.1.1.4 as marked for release like operator would.
+	cn.Status.IPAM.ReleaseIPs["1.1.1.4"] = ipamOption.IPAMMarkForRelease
+	// Attempts to allocate 1.1.1.4 should fail, since it's already marked for release
+	epipv4, _ := addressing.NewCiliumIPv4("1.1.1.4")
+	_, err := ipam.IPv4Allocator.Allocate(epipv4.IP(), "test")
+	c.Assert(err, NotNil)
+	// Call agent's CRD update function. status for 1.1.1.4 should change from marked for release to ready for release
+	sharedNodeStore.updateLocalNodeResource(cn)
+	c.Assert(string(cn.Status.IPAM.ReleaseIPs["1.1.1.4"]), checker.Equals, ipamOption.IPAMReadyForRelease)
+
+	// Verify that 1.1.1.3 is denied for release, since it's already in use
+	cn.Status.IPAM.ReleaseIPs["1.1.1.3"] = ipamOption.IPAMMarkForRelease
+	sharedNodeStore.updateLocalNodeResource(cn)
+	c.Assert(string(cn.Status.IPAM.ReleaseIPs["1.1.1.3"]), checker.Equals, ipamOption.IPAMDoNotRelease)
 }

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -64,6 +64,10 @@ type Configuration interface {
 	// enabled
 	HealthCheckingEnabled() bool
 
+	// UnreachableRoutesEnabled returns true when unreachable-routes is
+	// enabled
+	UnreachableRoutesEnabled() bool
+
 	// SetIPv4NativeRoutingCIDR is called by the IPAM module to announce
 	// the native IPv4 routing CIDR if it exists
 	SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR)

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -53,6 +53,7 @@ type testConfiguration struct{}
 func (t *testConfiguration) IPv4Enabled() bool                        { return true }
 func (t *testConfiguration) IPv6Enabled() bool                        { return true }
 func (t *testConfiguration) HealthCheckingEnabled() bool              { return true }
+func (t *testConfiguration) UnreachableRoutesEnabled() bool           { return false }
 func (t *testConfiguration) IPAMMode() string                         { return ipamOption.IPAMClusterPool }
 func (t *testConfiguration) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}
 func (t *testConfiguration) IPv4NativeRoutingCIDR() *cidr.CIDR        { return nil }

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -585,14 +585,37 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 // remove entries from IP release status map in ciliumnode CRD's status. These IPs need to be purged from
 // n.ipReleaseStatus
 func (n *Node) removeStaleReleaseIPs() {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 	for ip, status := range n.ipReleaseStatus {
 		if status != ipamOption.IPAMReleased {
 			continue
 		}
 		if _, ok := n.resource.Status.IPAM.ReleaseIPs[ip]; !ok {
-			n.deleteLocalReleaseStatus(ip)
+			delete(n.ipReleaseStatus, ip)
 		}
 	}
+}
+
+// handleIPReleaseResponse handles IPs agent has already responded to
+func (n *Node) handleIPReleaseResponse(markedIP string, ipsToRelease *[]string) bool {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	if n.resource.Status.IPAM.ReleaseIPs != nil {
+		if status, ok := n.resource.Status.IPAM.ReleaseIPs[markedIP]; ok {
+			switch status {
+			case ipamOption.IPAMReadyForRelease:
+				*ipsToRelease = append(*ipsToRelease, markedIP)
+			case ipamOption.IPAMDoNotRelease:
+				delete(n.ipsMarkedForRelease, markedIP)
+				delete(n.ipReleaseStatus, markedIP)
+			}
+			// 'released' state is already handled in removeStaleReleaseIPs()
+			// Other states don't need additional handling.
+			return true
+		}
+	}
+	return false
 }
 
 func (n *Node) deleteLocalReleaseStatus(ip string) {
@@ -605,6 +628,10 @@ func (n *Node) deleteLocalReleaseStatus(ip string) {
 // returns instanceMutated which tracks if state changed with the cloud provider and is used
 // to determine if IPAM pool maintainer trigger func needs to be invoked.
 func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err error) {
+	if n.manager.releaseExcessIPs {
+		n.removeStaleReleaseIPs()
+	}
+
 	a, err := n.determineMaintenanceAction()
 	if err != nil {
 		return false, err
@@ -613,10 +640,6 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 	// Maintenance request has already been fulfilled
 	if a == nil {
 		return false, nil
-	}
-
-	if n.ipReleaseStatus == nil {
-		n.ipReleaseStatus = make(map[string]string)
 	}
 
 	// Update timestamps for IPs from this iteration
@@ -642,8 +665,6 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 		n.ipsMarkedForRelease = make(map[string]time.Time)
 	}
 
-	n.removeStaleReleaseIPs()
-
 	for markedIP, ts := range n.ipsMarkedForRelease {
 		// Determine which IPs are still marked for release.
 		stillMarkedForRelease := false
@@ -665,20 +686,11 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 		if ts.Add(time.Duration(operatorOption.Config.ExcessIPReleaseDelay) * time.Second).After(time.Now()) {
 			continue
 		}
-		// Handle IPs we've already heard back from agent.
-		if n.resource.Status.IPAM.ReleaseIPs != nil {
-			if status, ok := n.resource.Status.IPAM.ReleaseIPs[markedIP]; ok {
-				switch status {
-				case ipamOption.IPAMReadyForRelease:
-					ipsToRelease = append(ipsToRelease, markedIP)
-				case ipamOption.IPAMDoNotRelease:
-					scopedLog.WithFields(logrus.Fields{logfields.IPAddr: markedIP}).Debug("IP release request denied from agent")
-					delete(n.ipsMarkedForRelease, markedIP)
-					n.deleteLocalReleaseStatus(markedIP)
-				}
-				continue
-			}
+		// Handling for IPs we've already heard back from agent.
+		if n.handleIPReleaseResponse(markedIP, &ipsToRelease) {
+			continue
 		}
+		// markedIP can now be considered excess and is not currently in an active handshake
 		ipsToMark = append(ipsToMark, markedIP)
 	}
 	// Update cilium node CRD with IPs that need to be marked for release
@@ -805,11 +817,14 @@ func (n *Node) MaintainIPPool(ctx context.Context) error {
 
 // Update cilium node IPAM status with excess IP release data
 func (n *Node) PopulateIPReleaseStatus(node *v2.CiliumNode) {
+	// maintainIPPool() might not have run yet since the last update from agent.
+	// Attempt to remove any stale entries
+	n.removeStaleReleaseIPs()
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 	releaseStatus := make(map[string]ipamTypes.IPReleaseStatus)
 	for ip, status := range n.ipReleaseStatus {
-		if existingStatus, ok := node.Status.IPAM.ReleaseIPs[ip]; ok {
+		if existingStatus, ok := node.Status.IPAM.ReleaseIPs[ip]; ok && status == ipamOption.IPAMMarkForRelease {
 			// retain status if agent already responded to this IP
 			if existingStatus == ipamOption.IPAMReadyForRelease || existingStatus == ipamOption.IPAMDoNotRelease {
 				releaseStatus[ip] = existingStatus

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -590,9 +590,15 @@ func (n *Node) removeStaleReleaseIPs() {
 			continue
 		}
 		if _, ok := n.resource.Status.IPAM.ReleaseIPs[ip]; !ok {
-			delete(n.ipReleaseStatus, ip)
+			n.deleteLocalReleaseStatus(ip)
 		}
 	}
+}
+
+func (n *Node) deleteLocalReleaseStatus(ip string) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	delete(n.ipReleaseStatus, ip)
 }
 
 // maintainIPPool attempts to allocate or release all required IPs to fulfill the needed gap.
@@ -652,7 +658,7 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 			// can be freed up. If the selected interface changes or if this IP is not excess anymore, remove entry
 			// from local maps.
 			delete(n.ipsMarkedForRelease, markedIP)
-			delete(n.ipReleaseStatus, markedIP)
+			n.deleteLocalReleaseStatus(markedIP)
 			continue
 		}
 		// Check if the IP release waiting period elapsed
@@ -668,7 +674,7 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 				case ipamOption.IPAMDoNotRelease:
 					scopedLog.WithFields(logrus.Fields{logfields.IPAddr: markedIP}).Debug("IP release request denied from agent")
 					delete(n.ipsMarkedForRelease, markedIP)
-					delete(n.ipReleaseStatus, markedIP)
+					n.deleteLocalReleaseStatus(markedIP)
 				}
 				continue
 			}
@@ -676,10 +682,12 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 		ipsToMark = append(ipsToMark, markedIP)
 	}
 	// Update cilium node CRD with IPs that need to be marked for release
+	n.mutex.Lock()
 	for _, ip := range ipsToMark {
 		scopedLog.WithFields(logrus.Fields{logfields.IPAddr: ip}).Debug("Marking IP for release")
 		n.ipReleaseStatus[ip] = ipamOption.IPAMMarkForRelease
 	}
+	n.mutex.Unlock()
 
 	if len(ipsToRelease) > 0 {
 		a.release.IPsToRelease = ipsToRelease
@@ -698,10 +706,12 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 			n.manager.metricsAPI.AddIPRelease(string(a.release.PoolID), int64(len(a.release.IPsToRelease)))
 
 			// Remove the IPs from ipsMarkedForRelease
+			n.mutex.Lock()
 			for _, ip := range ipsToRelease {
 				delete(n.ipsMarkedForRelease, ip)
 				n.ipReleaseStatus[ip] = ipamOption.IPAMReleased
 			}
+			n.mutex.Unlock()
 			return true, nil
 		}
 		n.manager.metricsAPI.IncAllocationAttempt("ip unassignment failed", string(a.release.PoolID))
@@ -795,6 +805,8 @@ func (n *Node) MaintainIPPool(ctx context.Context) error {
 
 // Update cilium node IPAM status with excess IP release data
 func (n *Node) PopulateIPReleaseStatus(node *v2.CiliumNode) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 	releaseStatus := make(map[string]ipamTypes.IPReleaseStatus)
 	for ip, status := range n.ipReleaseStatus {
 		if existingStatus, ok := node.Status.IPAM.ReleaseIPs[ip]; ok {

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -108,9 +108,10 @@ type Node struct {
 	ipsMarkedForRelease map[string]time.Time
 
 	// ipReleaseStatus tracks the state for every IP considered for release.
-	// 0 - IPAMMarkForRelease : Marked for Release
-	// 1 - IPAMReadyForRelease : Acknowledged as safe to release by agent
-	// 2 - IPAMDoNotRelease : Release request denied by agent
+	// IPAMMarkForRelease  : Marked for Release
+	// IPAMReadyForRelease : Acknowledged as safe to release by agent
+	// IPAMDoNotRelease    : Release request denied by agent
+	// IPAMReleased        : IP released by the operator
 	ipReleaseStatus map[string]string
 }
 
@@ -580,6 +581,20 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 	return a, nil
 }
 
+// removeStaleReleaseIPs Removes stale entries in local n.ipReleaseStatus. Once the handshake is complete agent would
+// remove entries from IP release status map in ciliumnode CRD's status. These IPs need to be purged from
+// n.ipReleaseStatus
+func (n *Node) removeStaleReleaseIPs() {
+	for ip, status := range n.ipReleaseStatus {
+		if status != ipamOption.IPAMReleased {
+			continue
+		}
+		if _, ok := n.resource.Status.IPAM.ReleaseIPs[ip]; !ok {
+			delete(n.ipReleaseStatus, ip)
+		}
+	}
+}
+
 // maintainIPPool attempts to allocate or release all required IPs to fulfill the needed gap.
 // returns instanceMutated which tracks if state changed with the cloud provider and is used
 // to determine if IPAM pool maintainer trigger func needs to be invoked.
@@ -620,6 +635,9 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 		// Resetting ipsMarkedForRelease if there are no IPs to release in this iteration
 		n.ipsMarkedForRelease = make(map[string]time.Time)
 	}
+
+	n.removeStaleReleaseIPs()
+
 	for markedIP, ts := range n.ipsMarkedForRelease {
 		// Determine which IPs are still marked for release.
 		stillMarkedForRelease := false
@@ -682,7 +700,7 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 			// Remove the IPs from ipsMarkedForRelease
 			for _, ip := range ipsToRelease {
 				delete(n.ipsMarkedForRelease, ip)
-				delete(n.ipReleaseStatus, ip)
+				n.ipReleaseStatus[ip] = ipamOption.IPAMReleased
 			}
 			return true, nil
 		}

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -408,6 +408,10 @@ func (n *Node) allocationNeeded() (needed bool) {
 func (n *Node) releaseNeeded() (needed bool) {
 	n.mutex.RLock()
 	needed = n.manager.releaseExcessIPs && !n.waitingForPoolMaintenance && n.resyncNeeded.IsZero() && n.stats.ExcessIPs > 0
+	if n.resource != nil {
+		releaseInProgress := len(n.resource.Status.IPAM.ReleaseIPs) > 0
+		needed = needed || releaseInProgress
+	}
 	n.mutex.RUnlock()
 	return
 }
@@ -597,6 +601,30 @@ func (n *Node) removeStaleReleaseIPs() {
 	}
 }
 
+// abortNoLongerExcessIPs allows for aborting release of IP if new allocations on the node result in a change of excess
+// count or the interface selected for release.
+func (n *Node) abortNoLongerExcessIPs(excessMap map[string]bool) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	if len(n.resource.Status.IPAM.ReleaseIPs) == 0 {
+		return
+	}
+	for ip, status := range n.resource.Status.IPAM.ReleaseIPs {
+		if excessMap[ip] {
+			continue
+		}
+		// Handshake can be aborted from every state except 'released'
+		// 'released' state is removed by the agent once the IP has been removed from ciliumnode's IPAM pool as well.
+		if status == ipamOption.IPAMReleased {
+			continue
+		}
+		if status, ok := n.ipReleaseStatus[ip]; ok && status != ipamOption.IPAMReleased {
+			delete(n.ipsMarkedForRelease, ip)
+			delete(n.ipReleaseStatus, ip)
+		}
+	}
+}
+
 // handleIPReleaseResponse handles IPs agent has already responded to
 func (n *Node) handleIPReleaseResponse(markedIP string, ipsToRelease *[]string) bool {
 	n.mutex.Lock()
@@ -628,17 +656,23 @@ func (n *Node) deleteLocalReleaseStatus(ip string) {
 // returns instanceMutated which tracks if state changed with the cloud provider and is used
 // to determine if IPAM pool maintainer trigger func needs to be invoked.
 func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err error) {
+	scopedLog := n.logger()
+	var ipsToMark []string
+	var ipsToRelease []string
+
 	if n.manager.releaseExcessIPs {
 		n.removeStaleReleaseIPs()
 	}
 
 	a, err := n.determineMaintenanceAction()
 	if err != nil {
+		n.abortNoLongerExcessIPs(nil)
 		return false, err
 	}
 
 	// Maintenance request has already been fulfilled
 	if a == nil {
+		n.abortNoLongerExcessIPs(nil)
 		return false, nil
 	}
 
@@ -651,14 +685,6 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 			}
 		}
 	}
-	scopedLog := n.logger()
-
-	// Attempt to release if :
-	// * IP is still marked for release in the current iteration's a.release.IPsToRelease
-	// * Marked for release for more than excess-ip-release-delay seconds
-	// * IP is not in use by any pod according to pod informer cache
-	var ipsToMark []string
-	var ipsToRelease []string
 
 	if n.ipsMarkedForRelease == nil || a.release == nil || len(a.release.IPsToRelease) == 0 {
 		// Resetting ipsMarkedForRelease if there are no IPs to release in this iteration
@@ -693,13 +719,23 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 		// markedIP can now be considered excess and is not currently in an active handshake
 		ipsToMark = append(ipsToMark, markedIP)
 	}
-	// Update cilium node CRD with IPs that need to be marked for release
+
 	n.mutex.Lock()
 	for _, ip := range ipsToMark {
 		scopedLog.WithFields(logrus.Fields{logfields.IPAddr: ip}).Debug("Marking IP for release")
 		n.ipReleaseStatus[ip] = ipamOption.IPAMMarkForRelease
 	}
 	n.mutex.Unlock()
+
+	// Abort handshake for IPs that are in the middle of handshake, but are no longer considered excess
+	var excessMap map[string]bool
+	if a.release != nil && len(a.release.IPsToRelease) > 0 {
+		excessMap = make(map[string]bool, len(a.release.IPsToRelease))
+		for _, ip := range a.release.IPsToRelease {
+			excessMap[ip] = true
+		}
+	}
+	n.abortNoLongerExcessIPs(excessMap)
 
 	if len(ipsToRelease) > 0 {
 		a.release.IPsToRelease = ipsToRelease

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -652,29 +652,23 @@ func (n *Node) deleteLocalReleaseStatus(ip string) {
 	delete(n.ipReleaseStatus, ip)
 }
 
-// maintainIPPool attempts to allocate or release all required IPs to fulfill the needed gap.
-// returns instanceMutated which tracks if state changed with the cloud provider and is used
-// to determine if IPAM pool maintainer trigger func needs to be invoked.
-func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err error) {
+// handleIPRelease implements IP release handshake needed for releasing excess IPs on the node.
+// Operator initiates the handshake after an IP remains unused and excess for more than the number of seconds configured
+// by excess-ip-release-delay flag. Operator uses a map in ciliumnode's IPAM status field to exchange handshake
+// information with the agent. Once the operator marks an IP for release, agent can either acknowledge or NACK IPs.
+// If agent acknowledges, operator will release the IP and update the state to released. After the IP is removed from
+// spec.ipam.pool and status is set to released, agent will remove the entry from map completing the handshake.
+// Handshake is implemented with 4 states :
+// * marked-for-release : Set by operator as possible candidate for IP
+// * ready-for-release  : Acknowledged as safe to release by agent
+// * do-not-release     : IP already in use / not owned by the node. Set by agent
+// * released           : IP successfully released. Set by operator
+//
+// Handshake would be aborted if there are new allocations and the node doesn't have IPs in excess anymore.
+func (n *Node) handleIPRelease(ctx context.Context, a *maintenanceAction) (instanceMutated bool, err error) {
 	scopedLog := n.logger()
 	var ipsToMark []string
 	var ipsToRelease []string
-
-	if n.manager.releaseExcessIPs {
-		n.removeStaleReleaseIPs()
-	}
-
-	a, err := n.determineMaintenanceAction()
-	if err != nil {
-		n.abortNoLongerExcessIPs(nil)
-		return false, err
-	}
-
-	// Maintenance request has already been fulfilled
-	if a == nil {
-		n.abortNoLongerExcessIPs(nil)
-		return false, nil
-	}
 
 	// Update timestamps for IPs from this iteration
 	releaseTS := time.Now()
@@ -769,7 +763,13 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 		}).WithError(err).Warning("Unable to unassign IPs from interface")
 		return false, err
 	}
+	return false, nil
+}
 
+// handleIPAllocation allocates the necessary IPs needed to resolve deficit on the node.
+// If existing interfaces don't have enough capacity, new interface would be created.
+func (n *Node) handleIPAllocation(ctx context.Context, a *maintenanceAction) (instanceMutated bool, err error) {
+	scopedLog := n.logger()
 	if a.allocation == nil {
 		scopedLog.Debug("No allocation action required")
 		return false, nil
@@ -795,6 +795,33 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 
 	err = n.createInterface(ctx, a.allocation)
 	return err != nil, err
+}
+
+// maintainIPPool attempts to allocate or release all required IPs to fulfill the needed gap.
+// returns instanceMutated which tracks if state changed with the cloud provider and is used
+// to determine if IPAM pool maintainer trigger func needs to be invoked.
+func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err error) {
+	if n.manager.releaseExcessIPs {
+		n.removeStaleReleaseIPs()
+	}
+
+	a, err := n.determineMaintenanceAction()
+	if err != nil {
+		n.abortNoLongerExcessIPs(nil)
+		return false, err
+	}
+
+	// Maintenance request has already been fulfilled
+	if a == nil {
+		n.abortNoLongerExcessIPs(nil)
+		return false, nil
+	}
+
+	if instanceMutated, err := n.handleIPRelease(ctx, a); instanceMutated || err != nil {
+		return instanceMutated, err
+	}
+
+	return n.handleIPAllocation(ctx, a)
 }
 
 func (n *Node) isInstanceRunning() (isRunning bool) {

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -18,8 +18,10 @@ package ipam
 import (
 	"context"
 	"fmt"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"time"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -100,6 +102,16 @@ type Node struct {
 	// retry is the trigger used to retry pool maintenance while the
 	// instances API is unstable
 	retry *trigger.Trigger
+
+	// Excess IPs from a cilium node would be marked for release only after a delay configured by excess-ip-release-delay
+	// flag. ipsMarkedForRelease tracks the IP and the timestamp at which it was marked for release.
+	ipsMarkedForRelease map[string]time.Time
+
+	// ipReleaseStatus tracks the state for every IP considered for release.
+	// 0 - IPAMMarkForRelease : Marked for Release
+	// 1 - IPAMReadyForRelease : Acknowledged as safe to release by agent
+	// 2 - IPAMDoNotRelease : Release request denied by agent
+	ipReleaseStatus map[string]string
 }
 
 // Statistics represent the IP allocation statistics of a node
@@ -260,7 +272,6 @@ func calculateNeededIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAllo
 	if neededIPs < 0 {
 		neededIPs = 0
 	}
-
 	return
 }
 
@@ -527,15 +538,6 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 	// request may have been resolved in the meantime.
 	if n.manager.releaseExcessIPs && stats.ExcessIPs > 0 {
 		a.release = n.ops.PrepareIPRelease(stats.ExcessIPs, scopedLog)
-		scopedLog = scopedLog.WithFields(logrus.Fields{
-			"available":         stats.AvailableIPs,
-			"used":              stats.UsedIPs,
-			"excess":            stats.ExcessIPs,
-			"releasing":         a.release.IPsToRelease,
-			"selectedInterface": a.release.InterfaceID,
-			"selectedPoolID":    a.release.PoolID,
-		})
-		scopedLog.Info("Releasing excess IPs from node")
 		return a, nil
 	}
 
@@ -578,39 +580,123 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 	return a, nil
 }
 
-// maintainIPPool attempts to allocate or release all required IPs to fulfill
-// the needed gap.
-func (n *Node) maintainIPPool(ctx context.Context) error {
+// maintainIPPool attempts to allocate or release all required IPs to fulfill the needed gap.
+// returns instanceMutated which tracks if state changed with the cloud provider and is used
+// to determine if IPAM pool maintainer trigger func needs to be invoked.
+func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err error) {
 	a, err := n.determineMaintenanceAction()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Maintenance request has already been fulfilled
 	if a == nil {
-		return nil
+		return false, nil
 	}
 
+	if n.ipReleaseStatus == nil {
+		n.ipReleaseStatus = make(map[string]string)
+	}
+
+	// Update timestamps for IPs from this iteration
+	releaseTS := time.Now()
+	if a.release != nil && a.release.IPsToRelease != nil {
+		for _, ip := range a.release.IPsToRelease {
+			if _, ok := n.ipsMarkedForRelease[ip]; !ok {
+				n.ipsMarkedForRelease[ip] = releaseTS
+			}
+		}
+	}
 	scopedLog := n.logger()
 
-	// Release excess addresses
-	if a.release != nil && len(a.release.IPsToRelease) > 0 {
+	// Attempt to release if :
+	// * IP is still marked for release in the current iteration's a.release.IPsToRelease
+	// * Marked for release for more than excess-ip-release-delay seconds
+	// * IP is not in use by any pod according to pod informer cache
+	var ipsToMark []string
+	var ipsToRelease []string
+
+	if n.ipsMarkedForRelease == nil || a.release == nil || len(a.release.IPsToRelease) == 0 {
+		// Resetting ipsMarkedForRelease if there are no IPs to release in this iteration
+		n.ipsMarkedForRelease = make(map[string]time.Time)
+	}
+	for markedIP, ts := range n.ipsMarkedForRelease {
+		// Determine which IPs are still marked for release.
+		stillMarkedForRelease := false
+		for _, ip := range a.release.IPsToRelease {
+			if markedIP == ip {
+				stillMarkedForRelease = true
+				break
+			}
+		}
+		if !stillMarkedForRelease {
+			// n.determineMaintenanceAction() only returns the IPs on the interface with maximum number of IPs that
+			// can be freed up. If the selected interface changes or if this IP is not excess anymore, remove entry
+			// from local maps.
+			delete(n.ipsMarkedForRelease, markedIP)
+			delete(n.ipReleaseStatus, markedIP)
+			continue
+		}
+		// Check if the IP release waiting period elapsed
+		if ts.Add(time.Duration(operatorOption.Config.ExcessIPReleaseDelay) * time.Second).After(time.Now()) {
+			continue
+		}
+		// Handle IPs we've already heard back from agent.
+		if n.resource.Status.IPAM.ReleaseIPs != nil {
+			if status, ok := n.resource.Status.IPAM.ReleaseIPs[markedIP]; ok {
+				switch status {
+				case ipamOption.IPAMReadyForRelease:
+					ipsToRelease = append(ipsToRelease, markedIP)
+				case ipamOption.IPAMDoNotRelease:
+					scopedLog.WithFields(logrus.Fields{logfields.IPAddr: markedIP}).Debug("IP release request denied from agent")
+					delete(n.ipsMarkedForRelease, markedIP)
+					delete(n.ipReleaseStatus, markedIP)
+				}
+				continue
+			}
+		}
+		ipsToMark = append(ipsToMark, markedIP)
+	}
+	// Update cilium node CRD with IPs that need to be marked for release
+	for _, ip := range ipsToMark {
+		scopedLog.WithFields(logrus.Fields{logfields.IPAddr: ip}).Debug("Marking IP for release")
+		n.ipReleaseStatus[ip] = ipamOption.IPAMMarkForRelease
+	}
+
+	if len(ipsToRelease) > 0 {
+		a.release.IPsToRelease = ipsToRelease
+		scopedLog = scopedLog.WithFields(logrus.Fields{
+			"available":         n.stats.AvailableIPs,
+			"used":              n.stats.UsedIPs,
+			"excess":            n.stats.ExcessIPs,
+			"excessIps":         a.release.IPsToRelease,
+			"releasing":         ipsToRelease,
+			"selectedInterface": a.release.InterfaceID,
+			"selectedPoolID":    a.release.PoolID,
+		})
+		scopedLog.Info("Releasing excess IPs from node")
 		err := n.ops.ReleaseIPs(ctx, a.release)
 		if err == nil {
 			n.manager.metricsAPI.AddIPRelease(string(a.release.PoolID), int64(len(a.release.IPsToRelease)))
-			return nil
+
+			// Remove the IPs from ipsMarkedForRelease
+			for _, ip := range ipsToRelease {
+				delete(n.ipsMarkedForRelease, ip)
+				delete(n.ipReleaseStatus, ip)
+			}
+			return true, nil
 		}
 		n.manager.metricsAPI.IncAllocationAttempt("ip unassignment failed", string(a.release.PoolID))
 		scopedLog.WithFields(logrus.Fields{
 			"selectedInterface":  a.release.InterfaceID,
 			"releasingAddresses": len(a.release.IPsToRelease),
 		}).WithError(err).Warning("Unable to unassign IPs from interface")
-		return err
+		return false, err
 	}
 
 	if a.allocation == nil {
 		scopedLog.Debug("No allocation action required")
-		return nil
+		return false, nil
 	}
 
 	// Assign needed addresses
@@ -621,7 +707,7 @@ func (n *Node) maintainIPPool(ctx context.Context) error {
 		if err == nil {
 			n.manager.metricsAPI.IncAllocationAttempt("success", string(a.allocation.PoolID))
 			n.manager.metricsAPI.AddIPAllocation(string(a.allocation.PoolID), int64(a.allocation.AvailableForAllocation))
-			return nil
+			return true, nil
 		}
 
 		n.manager.metricsAPI.IncAllocationAttempt("ip assignment failed", string(a.allocation.PoolID))
@@ -631,7 +717,8 @@ func (n *Node) maintainIPPool(ctx context.Context) error {
 		}).WithError(err).Warning("Unable to assign additional IPs to interface, will create new interface")
 	}
 
-	return n.createInterface(ctx, a.allocation)
+	err = n.createInterface(ctx, a.allocation)
+	return err != nil, err
 }
 
 func (n *Node) isInstanceRunning() (isRunning bool) {
@@ -675,15 +762,33 @@ func (n *Node) MaintainIPPool(ctx context.Context) error {
 		return nil
 	}
 
-	err := n.maintainIPPool(ctx)
+	instanceMutated, err := n.maintainIPPool(ctx)
 	if err == nil {
 		n.logger().Debug("Setting resync needed")
 		n.requireResync()
 	}
 	n.poolMaintenanceComplete()
 	n.recalculate()
-	n.manager.resyncTrigger.Trigger()
+	if instanceMutated || err != nil {
+		n.manager.resyncTrigger.Trigger()
+	}
 	return err
+}
+
+// Update cilium node IPAM status with excess IP release data
+func (n *Node) PopulateIPReleaseStatus(node *v2.CiliumNode) {
+	releaseStatus := make(map[string]ipamTypes.IPReleaseStatus)
+	for ip, status := range n.ipReleaseStatus {
+		if existingStatus, ok := node.Status.IPAM.ReleaseIPs[ip]; ok {
+			// retain status if agent already responded to this IP
+			if existingStatus == ipamOption.IPAMReadyForRelease || existingStatus == ipamOption.IPAMDoNotRelease {
+				releaseStatus[ip] = existingStatus
+				continue
+			}
+		}
+		releaseStatus[ip] = ipamTypes.IPReleaseStatus(status)
+	}
+	node.Status.IPAM.ReleaseIPs = releaseStatus
 }
 
 // syncToAPIServer synchronizes the contents of the CiliumNode resource
@@ -720,6 +825,7 @@ func (n *Node) syncToAPIServer() (err error) {
 		}
 
 		n.ops.PopulateStatusFields(node)
+		n.PopulateIPReleaseStatus(node)
 
 		err = n.update(origNode, node, retry, true)
 		if err == nil {

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -268,8 +268,10 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 	}()
 	if !ok {
 		node = &Node{
-			name:    resource.Name,
-			manager: n,
+			name:                resource.Name,
+			manager:             n,
+			ipsMarkedForRelease: make(map[string]time.Time),
+			ipReleaseStatus:     make(map[string]string),
 		}
 
 		node.ops = n.instancesAPI.CreateNode(resource, node)
@@ -317,7 +319,6 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 		node.poolMaintainer = poolMaintainer
 		node.k8sSync = k8sSync
 		n.nodes[node.name] = node
-
 		log.WithField(fieldName, resource.Name).Info("Discovered new CiliumNode custom resource")
 	}
 

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	metricsmock "github.com/cilium/cilium/pkg/ipam/metrics/mock"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
@@ -239,7 +240,8 @@ func newCiliumNode(node string, preAllocate, minAllocate, used int) *v2.CiliumNo
 		},
 		Status: v2.NodeStatus{
 			IPAM: ipamTypes.IPAMStatus{
-				Used: ipamTypes.AllocationMap{},
+				Used:       ipamTypes.AllocationMap{},
+				ReleaseIPs: map[string]ipamTypes.IPReleaseStatus{},
 			},
 		},
 	}
@@ -398,6 +400,7 @@ func (e *IPAMSuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 // - PreAllocate 4
 // - MaxAboveWatermark 4
 func (e *IPAMSuite) TestNodeManagerReleaseAddress(c *check.C) {
+	operatorOption.Config.ExcessIPReleaseDelay = 2
 	am := newAllocationImplementationMock()
 	c.Assert(am, check.Not(check.IsNil))
 	mngr, err := NewNodeManager(am, k8sapi, metricsapi, 10, true)
@@ -441,9 +444,22 @@ func (e *IPAMSuite) TestNodeManagerReleaseAddress(c *check.C) {
 
 	// Trigger resync manually, excess IPs should be released down to 18
 	// (10 used + 4 prealloc + 4 max-above-watermark)
-	node = mngr.Get("node3")
-	syncTime := mngr.instancesAPI.Resync(context.TODO())
-	mngr.resyncNode(context.TODO(), node, &resyncStats{}, syncTime)
+	// Excess timestamps should be registered after this trigger
+	mngr.resyncTrigger.Trigger()
+
+	// Acknowledge release IPs after 3 secs
+	time.AfterFunc(3*time.Second, func() {
+		// Excess delay duration should have elapsed by now, trigger resync again.
+		// IPs should be marked as excess
+		mngr.resyncTrigger.Trigger()
+		time.Sleep(1 * time.Second)
+		node.PopulateIPReleaseStatus(node.resource)
+		// Fake acknowledge IPs for release like agent would.
+		testutils.FakeAcknowledgeReleaseIps(node.resource)
+		// Resync one more time to process acknowledgements.
+		mngr.resyncTrigger.Trigger()
+	})
+
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
 	node = mngr.Get("node3")
 	c.Assert(node, check.Not(check.IsNil))

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -133,8 +133,8 @@ func (n *nodeOperationsMock) PrepareIPRelease(excessIPs int, scopedLog *logrus.E
 func (n *nodeOperationsMock) releaseIP(ip string) error {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
-	n.allocator.mutex.RLock()
-	defer n.allocator.mutex.RUnlock()
+	n.allocator.mutex.Lock()
+	defer n.allocator.mutex.Unlock()
 	for i, allocatedIP := range n.allocatedIPs {
 		if allocatedIP == ip {
 			n.allocatedIPs = append(n.allocatedIPs[:i], n.allocatedIPs[i+1:]...)

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -19,6 +19,7 @@ package ipam
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
@@ -123,8 +124,10 @@ func (n *nodeOperationsMock) PrepareIPRelease(excessIPs int, scopedLog *logrus.E
 	n.mutex.RLock()
 	excessIPs = math.IntMin(excessIPs, len(n.allocatedIPs))
 	r := &ReleaseAction{PoolID: testPoolID}
-	for i := 0; i < excessIPs; i++ {
-		r.IPsToRelease = append(r.IPsToRelease, n.allocatedIPs[i])
+	for i := 1; i <= excessIPs; i++ {
+		// Release from the end of slice to avoid releasing used IPs
+		releaseIndex := len(n.allocatedIPs) - (excessIPs + i - 1)
+		r.IPsToRelease = append(r.IPsToRelease, n.allocatedIPs[releaseIndex])
 	}
 	n.mutex.RUnlock()
 	return r
@@ -253,7 +256,7 @@ func newCiliumNode(node string, preAllocate, minAllocate, used int) *v2.CiliumNo
 
 func updateCiliumNode(cn *v2.CiliumNode, used int) *v2.CiliumNode {
 	cn.Spec.IPAM.Pool = ipamTypes.AllocationMap{}
-	for i := 0; i < used; i++ {
+	for i := 1; i <= used; i++ {
 		cn.Spec.IPAM.Pool[fmt.Sprintf("1.1.1.%d", i)] = ipamTypes.AllocationIP{Resource: "foo"}
 	}
 
@@ -465,6 +468,81 @@ func (e *IPAMSuite) TestNodeManagerReleaseAddress(c *check.C) {
 	c.Assert(node, check.Not(check.IsNil))
 	c.Assert(node.Stats().AvailableIPs, check.Equals, 18)
 	c.Assert(node.Stats().UsedIPs, check.Equals, 10)
+}
+
+// TestNodeManagerAbortRelease tests aborting IP release handshake if a new allocation on the node results in excess
+// being resolved
+func (e *IPAMSuite) TestNodeManagerAbortRelease(c *check.C) {
+	var wg sync.WaitGroup
+	operatorOption.Config.ExcessIPReleaseDelay = 2
+	am := newAllocationImplementationMock()
+	c.Assert(am, check.Not(check.IsNil))
+	mngr, err := NewNodeManager(am, k8sapi, metricsapi, 10, true)
+	c.Assert(err, check.IsNil)
+	c.Assert(mngr, check.Not(check.IsNil))
+
+	// Announce node, wait for IPs to become available
+	cn := newCiliumNode("node3", 1, 3, 0)
+	mngr.Update(cn)
+	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 1*time.Second), check.IsNil)
+
+	node := mngr.Get("node3")
+	c.Assert(node, check.Not(check.IsNil))
+	c.Assert(node.Stats().AvailableIPs, check.Equals, 3)
+	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+
+	// Use 3 out of 4 IPs, no additional IPs should be allocated
+	mngr.Update(updateCiliumNode(cn, 3))
+	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
+	node = mngr.Get("node3")
+	c.Assert(node, check.Not(check.IsNil))
+	c.Assert(node.Stats().AvailableIPs, check.Equals, 4)
+	c.Assert(node.Stats().UsedIPs, check.Equals, 3)
+
+	mngr.Update(updateCiliumNode(node.resource, 2))
+	node = mngr.Get("node3")
+	c.Assert(node, check.Not(check.IsNil))
+	c.Assert(node.Stats().AvailableIPs, check.Equals, 4)
+	c.Assert(node.Stats().UsedIPs, check.Equals, 2)
+
+	// Trigger resync manually, excess IPs should be released down to 3
+	// Excess timestamps should be registered after this trigger
+	mngr.resyncTrigger.Trigger()
+	wg.Add(1)
+
+	// Acknowledge release IPs after 3 secs
+	time.AfterFunc(3*time.Second, func() {
+		defer wg.Done()
+		// Excess delay duration should have elapsed by now, trigger resync again.
+		// IPs should be marked as excess
+		mngr.resyncTrigger.Trigger()
+		time.Sleep(1 * time.Second)
+		node.PopulateIPReleaseStatus(node.resource)
+
+		c.Assert(len(node.resource.Status.IPAM.ReleaseIPs), check.Equals, 1)
+
+		// Fake acknowledge IPs for release like agent would.
+		testutils.FakeAcknowledgeReleaseIps(node.resource)
+
+		// Use up one more IP to make excess = 0
+		mngr.Update(updateCiliumNode(node.resource, 3))
+		node.poolMaintainer.Trigger()
+		// Resync one more time to process acknowledgements.
+		mngr.resyncTrigger.Trigger()
+
+		time.Sleep(1 * time.Second)
+		node.PopulateIPReleaseStatus(node.resource)
+
+		// Verify that the entry for previously marked IP is removed, instead of being set to released state.
+		c.Assert(len(node.resource.Status.IPAM.ReleaseIPs), check.Equals, 0)
+	})
+
+	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
+	wg.Wait()
+	node = mngr.Get("node3")
+	c.Assert(node, check.Not(check.IsNil))
+	c.Assert(node.Stats().AvailableIPs, check.Equals, 4)
+	c.Assert(node.Stats().UsedIPs, check.Equals, 3)
 }
 
 type nodeState struct {

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -42,4 +42,5 @@ const (
 	IPAMMarkForRelease  = "marked-for-release"
 	IPAMReadyForRelease = "ready-for-release"
 	IPAMDoNotRelease    = "do-not-release"
+	IPAMReleased        = "released"
 )

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -37,3 +37,9 @@ const (
 	// IPAMAlibabaCloud is the value to select the AlibabaCloud ENI IPAM plugin for option.IPAM
 	IPAMAlibabaCloud = "alibabacloud"
 )
+
+const (
+	IPAMMarkForRelease  = "marked-for-release"
+	IPAMReadyForRelease = "ready-for-release"
+	IPAMDoNotRelease    = "do-not-release"
+)

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -113,7 +113,7 @@ type IPAMSpec struct {
 
 // IPReleaseStatus  defines the valid states in IP release handshake
 //
-// +kubebuilder:validation:Enum=marked-for-release;ready-for-release;do-not-release
+// +kubebuilder:validation:Enum=marked-for-release;ready-for-release;do-not-release;released
 type IPReleaseStatus string
 
 // IPAMStatus is the IPAM status of a node
@@ -136,6 +136,7 @@ type IPAMStatus struct {
 	// * marked-for-release : Set by operator as possible candidate for IP
 	// * ready-for-release  : Acknowledged as safe to release by agent
 	// * do-not-release     : IP already in use / not owned by the node. Set by agent
+	// * released           : IP successfully released. Set by operator
 	//
 	// +optional
 	ReleaseIPs map[string]IPReleaseStatus `json:"release-ips,omitempty"`

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -111,6 +111,11 @@ type IPAMSpec struct {
 	MaxAboveWatermark int `json:"max-above-watermark,omitempty"`
 }
 
+// IPReleaseStatus  defines the valid states in IP release handshake
+//
+// +kubebuilder:validation:Enum=marked-for-release;ready-for-release;do-not-release
+type IPReleaseStatus string
+
 // IPAMStatus is the IPAM status of a node
 //
 // This structure is embedded into v2.CiliumNode
@@ -125,6 +130,15 @@ type IPAMStatus struct {
 	//
 	// +optional
 	OperatorStatus OperatorStatus `json:"operator-status,omitempty"`
+
+	// ReleaseIPs tracks the state for every IP considered for release.
+	// value can be one of the following string :
+	// * marked-for-release : Set by operator as possible candidate for IP
+	// * ready-for-release  : Acknowledged as safe to release by agent
+	// * do-not-release     : IP already in use / not owned by the node. Set by agent
+	//
+	// +optional
+	ReleaseIPs map[string]IPReleaseStatus `json:"release-ips,omitempty"`
 }
 
 // OperatorStatus is the status used by cilium-operator to report

--- a/pkg/ipam/types/zz_generated.deepcopy.go
+++ b/pkg/ipam/types/zz_generated.deepcopy.go
@@ -95,6 +95,13 @@ func (in *IPAMStatus) DeepCopyInto(out *IPAMStatus) {
 		}
 	}
 	out.OperatorStatus = in.OperatorStatus
+	if in.ReleaseIPs != nil {
+		in, out := &in.ReleaseIPs, &out.ReleaseIPs
+		*out = make(map[string]IPReleaseStatus, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -124,6 +124,27 @@ func (in *IPAMStatus) DeepEqual(other *IPAMStatus) bool {
 		return false
 	}
 
+	if ((in.ReleaseIPs != nil) && (other.ReleaseIPs != nil)) || ((in.ReleaseIPs == nil) != (other.ReleaseIPs == nil)) {
+		in, other := &in.ReleaseIPs, &other.ReleaseIPs
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for key, inValue := range *in {
+				if otherValue, present := (*other)[key]; !present {
+					return false
+				} else {
+					if inValue != otherValue {
+						return false
+					}
+				}
+			}
+		}
+	}
+
 	return true
 }
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -511,6 +511,21 @@ spec:
                         description: Error is the error message set by cilium-operator.
                         type: string
                     type: object
+                  release-ips:
+                    additionalProperties:
+                      description: IPReleaseStatus  defines the valid states in IP
+                        release handshake
+                      enum:
+                      - marked-for-release
+                      - ready-for-release
+                      - do-not-release
+                      type: string
+                    description: 'ReleaseIPs tracks the state for every IP considered
+                      for release. value can be one of the following string : * marked-for-release
+                      : Set by operator as possible candidate for IP * ready-for-release  :
+                      Acknowledged as safe to release by agent * do-not-release     :
+                      IP already in use / not owned by the node. Set by agent'
+                    type: object
                   used:
                     additionalProperties:
                       description: AllocationIP is an IP which is available for allocation,

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -519,12 +519,14 @@ spec:
                       - marked-for-release
                       - ready-for-release
                       - do-not-release
+                      - released
                       type: string
                     description: 'ReleaseIPs tracks the state for every IP considered
                       for release. value can be one of the following string : * marked-for-release
                       : Set by operator as possible candidate for IP * ready-for-release  :
                       Acknowledged as safe to release by agent * do-not-release     :
-                      IP already in use / not owned by the node. Set by agent'
+                      IP already in use / not owned by the node. Set by agent * released           :
+                      IP successfully released. Set by operator'
                     type: object
                   used:
                     additionalProperties:

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -151,6 +151,9 @@ const (
 	// EnableTracing enables tracing mode in the agent.
 	EnableTracing = "enable-tracing"
 
+	// Add unreachable routes on pod deletion
+	EnableUnreachableRoutes = "enable-unreachable-routes"
+
 	// EncryptInterface enables encryption on specified interface
 	EncryptInterface = "encrypt-interface"
 
@@ -1454,6 +1457,7 @@ type DaemonConfig struct {
 	EnableHostServicesPeer        bool
 	EnablePolicy                  string
 	EnableTracing                 bool
+	EnableUnreachableRoutes       bool
 	EnvoyLog                      string
 	DisableEnvoyVersionCheck      bool
 	FixedIdentityMapping          map[string]string
@@ -2178,6 +2182,11 @@ func (c *DaemonConfig) TracingEnabled() bool {
 	return c.Opts.IsEnabled(PolicyTracing)
 }
 
+// UnreachableRoutesEnabled returns true if unreachable routes is enabled
+func (c *DaemonConfig) UnreachableRoutesEnabled() bool {
+	return c.EnableUnreachableRoutes
+}
+
 // EndpointStatusIsEnabled returns true if a particular EndpointStatus* feature
 // is enabled
 func (c *DaemonConfig) EndpointStatusIsEnabled(option string) bool {
@@ -2462,6 +2471,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableExternalIPs = viper.GetBool(EnableExternalIPs)
 	c.EnableL7Proxy = viper.GetBool(EnableL7Proxy)
 	c.EnableTracing = viper.GetBool(EnableTracing)
+	c.EnableUnreachableRoutes = viper.GetBool(EnableUnreachableRoutes)
 	c.EnableNodePort = viper.GetBool(EnableNodePort)
 	c.EnableSVCSourceRangeCheck = viper.GetBool(EnableSVCSourceRangeCheck)
 	c.EnableHostPort = viper.GetBool(EnableHostPort)

--- a/pkg/testutils/ipam.go
+++ b/pkg/testutils/ipam.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Authors of Cilium
+
+package testutils
+
+import (
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+// FakeAcknowledgeReleaseIps Fake acknowledge IPs marked for release like cilium agent would.
+func FakeAcknowledgeReleaseIps(cn *v2.CiliumNode) {
+	for ip, status := range cn.Status.IPAM.ReleaseIPs {
+		if status == ipamOption.IPAMMarkForRelease {
+			cn.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMReadyForRelease
+		}
+	}
+}


### PR DESCRIPTION
This PR cherry-picks a variety of commits from upstream back to v1.10. 

Upstream PR's:
* https://github.com/cilium/cilium/pull/17856
* https://github.com/cilium/cilium/pull/17939
* https://github.com/cilium/cilium/pull/18217
* https://github.com/cilium/cilium/pull/18296
* https://github.com/cilium/cilium/pull/18330
* https://github.com/cilium/cilium/pull/18505
