### PR TITLE
[ipam] Fixup duplicated function due to bad merge

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -446,14 +446,6 @@ func (n *nodeStore) setOwnNodeWithoutPoolUpdate(node *ciliumv2.CiliumNode) {
 	n.mutex.Unlock()
 }
 
-// setOwnNodeWithoutPoolUpdate overwrites the local node copy (e.g. to update
-// its resourceVersion) without updating the available IP pool.
-func (n *nodeStore) setOwnNodeWithoutPoolUpdate(node *ciliumv2.CiliumNode) {
-	n.mutex.Lock()
-	n.ownNode = node
-	n.mutex.Unlock()
-}
-
 // refreshNodeTrigger is called to refresh the custom resource after taking the
 // configured rate limiting into account
 //


### PR DESCRIPTION
When I merged in the upstream changes to v1.10-dd, it looks like git decided to duplicate this function which I now see if you review the merge commit diff here: https://github.com/DataDog/cilium/commit/b9e69266ab89c5929864d802ff29ab0ddc92c913#diff-ee217c56bdd2148328d1e51a53f1f29533487b5f2f610de9983b5fa23561554f 


This drops that change as we already had the function since I had previously cherry-picked the upstream commit that added it. 