### PR TITLE
Cherry-pick: routing: Fix the incorrect deletion of IP rules

### DIFF
--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -242,7 +242,8 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 		option.Config.IPAM == ipamOption.IPAMAzure) && result != nil {
 		var routingInfo *linuxrouting.RoutingInfo
 		routingInfo, err = linuxrouting.NewRoutingInfo(result.GatewayIP, result.CIDRs,
-			result.PrimaryMAC, result.InterfaceNumber, option.Config.EnableIPv4Masquerade)
+			result.PrimaryMAC, result.InterfaceNumber, option.Config.IPAM,
+			option.Config.EnableIPv4Masquerade)
 		if err != nil {
 			err = fmt.Errorf("failed to create router info %w", err)
 			return
@@ -416,6 +417,7 @@ func (d *Daemon) parseHealthEndpointInfo(result *ipam.AllocationResult) error {
 		result.CIDRs,
 		result.PrimaryMAC,
 		result.InterfaceNumber,
+		option.Config.IPAM,
 		option.Config.EnableIPv4Masquerade,
 	)
 	return err

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -50,6 +50,9 @@ type RoutingInfo struct {
 	// egress traffic is directed to. This is used to compute the table ID for
 	// the per-ENI tables.
 	InterfaceNumber int
+
+	// IpamMode tells us which IPAM mode is being used (e.g., ENI, AKS).
+	IpamMode string
 }
 
 func (info *RoutingInfo) GetIPv4CIDRs() []net.IPNet {
@@ -69,11 +72,11 @@ func (info *RoutingInfo) GetInterfaceNumber() int {
 // (on either ENI or Azure interface) is the only supported path currently.
 // Azure does not support masquerade yet (subnets CIDRs aren't provided):
 // until it does, we forward a masquerade bool to opt out ipam.Cidrs use.
-func NewRoutingInfo(gateway string, cidrs []string, mac, ifaceNum string, masquerade bool) (*RoutingInfo, error) {
-	return parse(gateway, cidrs, mac, ifaceNum, masquerade)
+func NewRoutingInfo(gateway string, cidrs []string, mac, ifaceNum, ipamMode string, masquerade bool) (*RoutingInfo, error) {
+	return parse(gateway, cidrs, mac, ifaceNum, ipamMode, masquerade)
 }
 
-func parse(gateway string, cidrs []string, macAddr, ifaceNum string, masquerade bool) (*RoutingInfo, error) {
+func parse(gateway string, cidrs []string, macAddr, ifaceNum, ipamMode string, masquerade bool) (*RoutingInfo, error) {
 	ip := net.ParseIP(gateway)
 	if ip == nil {
 		return nil, fmt.Errorf("invalid ip: %s", gateway)
@@ -109,5 +112,6 @@ func parse(gateway string, cidrs []string, macAddr, ifaceNum string, masquerade 
 		MasterIfMAC:     parsedMAC,
 		Masquerade:      masquerade,
 		InterfaceNumber: parsedIfaceNum,
+		IpamMode:        ipamMode,
 	}, nil
 }

--- a/pkg/datapath/linux/routing/info_test.go
+++ b/pkg/datapath/linux/routing/info_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/checker"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/mac"
 
 	"gopkg.in/check.v1"
@@ -127,6 +128,7 @@ func (e *LinuxRoutingSuite) TestParse(c *check.C) {
 				IPv4CIDRs:       validCIDRs,
 				MasterIfMAC:     fakeMAC,
 				InterfaceNumber: 1,
+				IpamMode:        ipamOption.IPAMENI,
 			},
 			wantErr: false,
 		},
@@ -141,6 +143,7 @@ func (e *LinuxRoutingSuite) TestParse(c *check.C) {
 				IPv4Gateway: net.ParseIP("192.168.1.1"),
 				IPv4CIDRs:   []net.IPNet{},
 				MasterIfMAC: fakeMAC,
+				IpamMode:    ipamOption.IPAMENI,
 			},
 			wantErr: false,
 		},
@@ -156,7 +159,7 @@ func (e *LinuxRoutingSuite) TestParse(c *check.C) {
 	}
 	for _, tt := range tests {
 		c.Log(tt.name)
-		rInfo, err := NewRoutingInfo(tt.gateway, tt.cidrs, tt.macAddr, tt.ifaceNum, tt.masq)
+		rInfo, err := NewRoutingInfo(tt.gateway, tt.cidrs, tt.macAddr, tt.ifaceNum, ipamOption.IPAMENI, tt.masq)
 		c.Assert(rInfo, checker.DeepEquals, tt.wantRInfo)
 		c.Assert((err != nil), check.Equals, tt.wantErr)
 	}

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -85,7 +85,8 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool) error {
 		tableID = computeTableIDFromIfaceNumber(info.InterfaceNumber)
 	}
 
-	if info.Masquerade {
+	// The condition here should mirror the condition in Delete.
+	if info.Masquerade && info.IpamMode == ipamOption.IPAMENI {
 		// Lookup a VPC specific table for all traffic from an endpoint to the
 		// CIDR configured for the VPC on which the endpoint has the IP on.
 		for _, cidr := range info.IPv4CIDRs {

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -188,7 +188,9 @@ func Delete(ip net.IP, compat bool) error {
 	}
 
 	// Egress rules
-	if info := node.GetRouterInfo(); info != nil && option.Config.IPAM == ipamOption.IPAMENI {
+	// The condition here should mirror the conditions in Configure.
+	info := node.GetRouterInfo()
+	if info != nil && option.Config.EnableIPv4Masquerade && option.Config.IPAM == ipamOption.IPAMENI {
 		ipv4CIDRs := info.GetIPv4CIDRs()
 		cidrs := make([]*net.IPNet, 0, len(ipv4CIDRs))
 		for i := range ipv4CIDRs {

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -260,6 +261,7 @@ func getFakes(c *C) (net.IP, RoutingInfo) {
 		[]string{fakeCIDR.String()},
 		fakeMAC.String(),
 		"1",
+		ipamOption.IPAMENI,
 		true,
 	)
 	c.Assert(err, IsNil)

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -62,6 +62,7 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 		cidrs,
 		ipam.MasterMac,
 		ipam.InterfaceNumber,
+		conf.IpamMode,
 		masq,
 	)
 	if err != nil {


### PR DESCRIPTION
This cherry-picks https://github.com/cilium/cilium/pull/19277/commits/d02f9a079dd0394dcfd00d497bec21ff9f67da1f and https://github.com/cilium/cilium/pull/19277/commits/3eeafdf65ddf42012f7449115612571181abae0f back to 1.10 