### PR TITLE
Remove checking if potential router IP is in CIDR

### DIFF
--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -436,17 +436,7 @@ func chooseHostIPsToRestore(ipv6 bool, fromK8s, fromFS net.IP, cidr *cidr.CIDR) 
 		} else {
 			ip = fromFS
 			err = errMismatch
-
-			// Check if we need to fallback to using the fromK8s IP, in the
-			// case that the IP from the FS is not within the CIDR. If we
-			// fallback, then we also need to check the fromK8s IP is also
-			// within the CIDR.
-			if cidr != nil && cidr.Contains(ip) {
-				return
-			} else if cidr != nil && cidr.Contains(fromK8s) {
-				ip = fromK8s
-				return
-			}
+			return
 		}
 	case fromK8s == nil && fromFS != nil:
 		ip = fromFS
@@ -458,11 +448,6 @@ func chooseHostIPsToRestore(ipv6 bool, fromK8s, fromFS net.IP, cidr *cidr.CIDR) 
 		return
 	}
 
-	if cidr != nil && cidr.Contains(ip) {
-		return
-	}
-
-	err = errDoesNotBelong
 	return
 }
 


### PR DESCRIPTION
This logic does not currently support checking if the potential router IP is in a VPC secondary CIDR. In our environment, we will not have a node with IP's that are not in any routable CIDR and can simply not use the `cidr.Contains()` logic. This PR drops that will we work on getting secondary VPC CIDR support included. 