### PR TITLE
Cherry-pick: Making operator aware of pending pod backlog on nodes for IP allocations

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -314,12 +314,18 @@ following criteria:
 
  * The subnet associated with the ENI has IPs available for allocation
 
-The following formula is used to determine how many IPs are allocated on the
-ENI:
+The following formula is used to determine how many IPs are allocated on the ENI:
 
 .. code-block:: go
 
-      min(AvailableOnSubnet, min(AvailableOnENI, NeededAddresses + spec.ipam.max-above-watermark))
+      // surgeAllocate kicks in if numPendingPods is greater than NeededAddresses
+      min(AvailableOnSubnet, min(AvailableOnENI, NeededAddresses + spec.ipam.max-above-watermark + surgeAllocate))
+
+.. note::
+
+   In scenarios where the pre-allocated number is lower than the number of pending pods on the node, the operator will
+   pro-actively allocate more than the pre-allocated number of IPs to avoid having to wait for the next allocation
+   cycles.
 
 This means that the number of IPs allocated in a single allocation cycle can be
 less than what is required to fulfill ``spec.ipam.pre-allocate``.

--- a/operator/watchers/pod.go
+++ b/operator/watchers/pod.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+const PodNodeNameIndex = "pod-node"
+
 var (
 	// PodStore has a minimal copy of all pods running in the cluster.
 	// Warning: The pods stored in the cache are not intended to be used for Update
@@ -47,15 +49,28 @@ var (
 	UnmanagedPodStoreSynced = make(chan struct{})
 )
 
+// podNodeNameIndexFunc indexes pods by node name
+func podNodeNameIndexFunc(obj interface{}) ([]string, error) {
+	pod := obj.(*slim_corev1.Pod)
+	if pod.Spec.NodeName != "" {
+		return []string{pod.Spec.NodeName}, nil
+	}
+	return []string{}, nil
+}
+
 func PodsInit(k8sClient kubernetes.Interface, stopCh <-chan struct{}) {
 	var podInformer cache.Controller
-	PodStore, podInformer = informer.NewInformer(
+	PodStore = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{
+		PodNodeNameIndex: podNodeNameIndexFunc,
+	})
+	podInformer = informer.NewInformerWithStore(
 		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
 			"pods", v1.NamespaceAll, fields.Everything()),
 		&slim_corev1.Pod{},
 		0,
 		cache.ResourceEventHandlerFuncs{},
 		convertToPod,
+		PodStore,
 	)
 	go podInformer.Run(stopCh)
 
@@ -76,6 +91,9 @@ func convertToPod(obj interface{}) interface{} {
 				Namespace:       concreteObj.Namespace,
 				ResourceVersion: concreteObj.ResourceVersion,
 			},
+			Spec: slim_corev1.PodSpec{
+				NodeName: concreteObj.Spec.NodeName,
+			},
 			Status: slim_corev1.PodStatus{
 				Phase: concreteObj.Status.Phase,
 			},
@@ -95,6 +113,9 @@ func convertToPod(obj interface{}) interface{} {
 					Name:            pod.Name,
 					Namespace:       pod.Namespace,
 					ResourceVersion: pod.ResourceVersion,
+				},
+				Spec: slim_corev1.PodSpec{
+					NodeName: pod.Spec.NodeName,
 				},
 				Status: slim_corev1.PodStatus{
 					Phase: pod.Status.Phase,

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -22,15 +22,19 @@ import (
 	"time"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/math"
 	"github.com/cilium/cilium/pkg/trigger"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (
@@ -113,6 +117,9 @@ type Node struct {
 	// IPAMDoNotRelease    : Release request denied by agent
 	// IPAMReleased        : IP released by the operator
 	ipReleaseStatus map[string]string
+
+	// logLimiter rate limits potentially repeating warning logs
+	logLimiter logging.Limiter
 }
 
 // Statistics represent the IP allocation statistics of a node
@@ -254,6 +261,26 @@ func (n *Node) GetNeededAddresses() int {
 		return stats.ExcessIPs * -1
 	}
 	return 0
+}
+
+// getPendingPodCount computes the number of pods in pending state on a given node. watchers.PodStore is assumed to be
+// initialized before this function is called.
+func getPendingPodCount(nodeName string) (int, error) {
+	pendingPods := 0
+	if watchers.PodStore == nil {
+		return pendingPods, fmt.Errorf("pod store uninitialized")
+	}
+	values, err := watchers.PodStore.(cache.Indexer).ByIndex(watchers.PodNodeNameIndex, nodeName)
+	if err != nil {
+		return pendingPods, fmt.Errorf("unable to access pod to node name index: %w", err)
+	}
+	for _, pod := range values {
+		p := pod.(*v1.Pod)
+		if p.Status.Phase == v1.PodPending {
+			pendingPods++
+		}
+	}
+	return pendingPods, nil
 }
 
 func calculateNeededIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAllocate int) (neededIPs int) {
@@ -557,8 +584,20 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 		return nil, err
 	}
 
+	surgeAllocate := 0
+	numPendingPods, err := getPendingPodCount(n.name)
+	if err != nil {
+		if n.logLimiter.Allow() {
+			scopedLog.WithError(err).Warningf("Unable to compute pending pods, will not surge-allocate")
+		}
+	} else if numPendingPods > stats.NeededIPs {
+		surgeAllocate = numPendingPods - stats.NeededIPs
+	}
+
 	n.mutex.RLock()
-	a.allocation.MaxIPsToAllocate = stats.NeededIPs + n.getMaxAboveWatermark()
+	// handleIPAllocation() takes a min of MaxIPsToAllocate and IPs available for allocation on the interface.
+	// This makes sure we don't try to allocate more than what's available.
+	a.allocation.MaxIPsToAllocate = stats.NeededIPs + n.getMaxAboveWatermark() + surgeAllocate
 	n.mutex.RUnlock()
 
 	if a.allocation != nil {
@@ -878,7 +917,7 @@ func (n *Node) MaintainIPPool(ctx context.Context) error {
 	return err
 }
 
-// Update cilium node IPAM status with excess IP release data
+// PopulateIPReleaseStatus Updates cilium node IPAM status with excess IP release data
 func (n *Node) PopulateIPReleaseStatus(node *v2.CiliumNode) {
 	// maintainIPPool() might not have run yet since the last update from agent.
 	// Attempt to remove any stale entries

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -25,6 +25,7 @@ import (
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/trigger"
 
 	"github.com/sirupsen/logrus"
@@ -272,6 +273,7 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 			manager:             n,
 			ipsMarkedForRelease: make(map[string]time.Time),
 			ipReleaseStatus:     make(map[string]string),
+			logLimiter:          logging.NewLimiter(10*time.Second, 3), // 1 log / 10 secs, burst of 3
 		}
 
 		node.ops = n.instancesAPI.CreateNode(resource, node)


### PR DESCRIPTION
Cherry-picks https://github.com/cilium/cilium/pull/19007 to 1.10. Minor merge conflict with the imports in `pkg/ipam/node.go` that I fixed up, otherwise applied cleanly. 