### PR TITLE
Clean up IP rules when router IP restoration fails

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -94,6 +95,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sync/semaphore"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -327,9 +329,41 @@ func removeOldRouterState(restoredIP net.IP) error {
 		if err := netlink.AddrDel(l, &a); err != nil {
 			errs = append(errs, fmt.Errorf("failed to remove IP %s: %w", a.IP, err))
 		}
+		// Clean up old router based IP rules installed for encryption. See https://github.com/cilium/cilium/pull/14924
+		// Previously, these rules were always installed in ENI mode. This clean up is not gated with IPsec to handle
+		// for cases where a rollout disables IPsec or if user upgrades from prior versions.
+		if option.Config.IPAM == ipamOption.IPAMENI {
+			err := removeOldRouterIPRules(a.IP)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to remove IP rule for old router IP %s: %w", a.IP, err))
+			}
+		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("failed to remove all old router IPs: %v", errs)
+		return fmt.Errorf("failed to clean up old router state: %v", errs)
+	}
+
+	return nil
+}
+
+// removeOldRouterIPRules cleans up IP rules installed for the old router IP.
+func removeOldRouterIPRules(ip net.IP) error {
+	info := node.GetRouterInfo()
+	cidrs := info.GetIPv4CIDRs()
+	routerIP := net.IPNet{
+		IP:   ip,
+		Mask: net.CIDRMask(32, 32),
+	}
+	var errs []error
+	for _, cidr := range cidrs {
+		err := linuxrouting.DeleteRule(&routerIP, &cidr, info.GetMac().String(), info.GetInterfaceNumber())
+		if err != nil && !errors.Is(err, unix.ENOENT) {
+			// Ignore rules that are already deleted.
+			errs = append(errs, fmt.Errorf("unable to delete ip rule from %s to %s: %w", ip.String(), cidr.String(), err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to clean up ip rules for cilium_host: %v", errs)
 	}
 
 	return nil

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -242,24 +242,29 @@ func Delete(ip net.IP, compat bool) error {
 	return nil
 }
 
-// SetupRules installs routing rules based on the passed attributes. It accounts
-// for option.Config.EgressMultiHomeIPRuleCompat while configuring the rules.
-func SetupRules(from, to *net.IPNet, mac string, ifaceNum int) error {
-	var (
-		prio    int
-		tableId int
-	)
-
+// getPriorityAndTableId computes priority and table ID needed for IP rules by accounting for
+// option.Config.EgressMultiHomeIPRuleCompat flag.
+func getPriorityAndTableId(mac string, ifaceNum int) (prio int, tableId int, err error) {
 	if option.Config.EgressMultiHomeIPRuleCompat {
 		prio = linux_defaults.RulePriorityEgress
 		ifindex, err := retrieveIfaceIdxFromMAC(mac)
 		if err != nil {
-			return fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
+			return prio, tableId, fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
 		}
 		tableId = ifindex
 	} else {
 		prio = linux_defaults.RulePriorityEgressv2
 		tableId = computeTableIDFromIfaceNumber(ifaceNum)
+	}
+	return prio, tableId, nil
+}
+
+// SetupRule installs routing rule based on the passed attributes. It accounts
+// for option.Config.EgressMultiHomeIPRuleCompat while configuring the rules.
+func SetupRule(from, to *net.IPNet, mac string, ifaceNum int) error {
+	prio, tableId, err := getPriorityAndTableId(mac, ifaceNum)
+	if err != nil {
+		return err
 	}
 	return route.ReplaceRule(route.Rule{
 		Priority: prio,
@@ -267,6 +272,22 @@ func SetupRules(from, to *net.IPNet, mac string, ifaceNum int) error {
 		To:       to,
 		Table:    tableId,
 	})
+}
+
+// DeleteRule deletes the routing rule based on the passed attributes. It accounts
+// for option.Config.EgressMultiHomeIPRuleCompat while deleting the rule.
+func DeleteRule(from, to *net.IPNet, mac string, ifaceNum int) error {
+	prio, tableId, err := getPriorityAndTableId(mac, ifaceNum)
+	if err != nil {
+		return err
+	}
+	rule := route.Rule{
+		Priority: prio,
+		From:     from,
+		To:       to,
+		Table:    tableId,
+	}
+	return deleteRule(rule)
 }
 
 // RetrieveIfaceNameFromMAC finds the corresponding device name for a

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -167,9 +167,12 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing datapath.NodeAddre
 		IP:   nodeAddressing.IPv4().Router(),
 		Mask: net.CIDRMask(32, 32),
 	}
-	for _, cidr := range cidrs {
-		if err = linuxrouting.SetupRules(&routerIP, &cidr, info.GetMac().String(), info.GetInterfaceNumber()); err != nil {
-			return nil, fmt.Errorf("unable to install ip rule for cilium_host: %w", err)
+
+	if option.Config.EnableIPSec {
+		for _, cidr := range cidrs {
+			if err = linuxrouting.SetupRule(&routerIP, &cidr, info.GetMac().String(), info.GetInterfaceNumber()); err != nil {
+				return nil, fmt.Errorf("unable to install ip rule for cilium_host: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Cherry-picks https://github.com/cilium/cilium/pull/19625/commits/daaf55cab42da3cc971efebe9f81612ed86ef064 back to v1.10. Only minor merge conflicts with the import changes which should be resolved correctly. 