### PR TITLE
Add support to opt-in for using ENI's primary IP for allocations - 1.10 backport

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -14,6 +14,7 @@ cilium-operator-aws [flags]
       --aws-enable-prefix-delegation              Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-instance-limit-mapping map            Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"}
       --aws-release-excess-ips                    Enable releasing excess free IP addresses from AWS ENI.
+      --aws-use-primary-address                   Allows for using primary address of the ENI for allocations on the node
       --bgp-announce-lb-ip                        Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                    Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
       --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -16,6 +16,7 @@ cilium-operator [flags]
       --aws-instance-limit-mapping map            Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"}
       --aws-release-excess-ips                    Enable releasing excess free IP addresses from AWS ENI.
       --azure-cloud-name string                   Name of the Azure cloud being used (default "AzurePublicCloud")
+      --aws-use-primary-address                   Allows for using primary address of the ENI for allocations on the node
       --azure-resource-group string               Resource group to use for Azure IPAM
       --azure-subscription-id string              Subscription ID to access Azure API
       --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations (default true)
@@ -90,5 +91,5 @@ cilium-operator [flags]
 
 ### SEE ALSO
 
-* [cilium-operator metrics](cilium-operator_metrics.html)	 - Access metric status of the operator
+* [cilium-operator metrics](cilium-operator_metrics.html)     - Access metric status of the operator
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -172,6 +172,10 @@ const (
 	// e.g. "ec2-fips.us-west-1.amazonaws.com" to use a FIPS endpoint in the us-west-1 region.
 	EC2APIEndpoint = "ec2-api-endpoint"
 
+	// AWSUsePrimaryAddress specifies whether an interface's primary address should be available for allocations on
+	// node
+	AWSUsePrimaryAddress = "aws-use-primary-address"
+
 	// Azure options
 
 	// AzureCloudName is the name of the cloud being used
@@ -187,7 +191,7 @@ const (
 	// for retrieving Azure API credentials
 	AzureUserAssignedIdentityID = "azure-user-assigned-identity-id"
 
-	// AzureUsePrimaryAddress specify wether we should use or ignore the interface's
+	// AzureUsePrimaryAddress specifies whether we should use or ignore the interface's
 	// primary IPConfiguration
 	AzureUsePrimaryAddress = "azure-use-primary-address"
 
@@ -365,6 +369,10 @@ type OperatorConfig struct {
 	// IP addresses. Allows for increased pod density on nodes.
 	AWSEnablePrefixDelegation bool
 
+	// AWSUsePrimaryAddress specifies whether an interface's primary address should be available for allocations on
+	// node
+	AWSUsePrimaryAddress bool
+
 	// UpdateEC2AdapterLimitViaAPI configures the operator to use the EC2 API to fill out the
 	// instancetype to adapter limit mapping.
 	UpdateEC2AdapterLimitViaAPI bool
@@ -475,6 +483,7 @@ func (c *OperatorConfig) Populate() {
 
 	c.AWSReleaseExcessIPs = viper.GetBool(AWSReleaseExcessIPs)
 	c.AWSEnablePrefixDelegation = viper.GetBool(AWSEnablePrefixDelegation)
+	c.AWSUsePrimaryAddress = viper.GetBool(AWSUsePrimaryAddress)
 	c.UpdateEC2AdapterLimitViaAPI = viper.GetBool(UpdateEC2AdapterLimitViaAPI)
 	c.EC2APIEndpoint = viper.GetString(EC2APIEndpoint)
 	c.ExcessIPReleaseDelay = viper.GetInt(ExcessIPReleaseDelay)

--- a/operator/provider_aws_flags.go
+++ b/operator/provider_aws_flags.go
@@ -52,6 +52,9 @@ func init() {
 	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPI, false, "Use the EC2 API to update the instance type to adapter limits")
 	option.BindEnv(operatorOption.UpdateEC2AdapterLimitViaAPI)
 
+	flags.Bool(operatorOption.AWSUsePrimaryAddress, false, "Allows for using primary address of the ENI for allocations on the node")
+	option.BindEnv(operatorOption.AWSUsePrimaryAddress)
+
 	flags.String(operatorOption.EC2APIEndpoint, "", "AWS API endpoint for the EC2 service")
 	option.BindEnv(operatorOption.EC2APIEndpoint)
 

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -228,13 +228,19 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (a *ipam.AllocationA
 			continue
 		}
 
-		effectiveLimits := limits.IPv4
-		if n.node.Ops().IsPrefixDelegated() {
-			effectiveLimits = limits.IPv4 * option.ENIPDBlockSizeIPv4
-		}
 		// The limits include the primary IP, so we need to take it into account
-		// when computing the amount of available addresses on the ENI.
-		availableOnENI := math.IntMax(effectiveLimits-len(e.Addresses)-1, 0)
+		// when computing the effective number of available addresses on the ENI.
+		effectiveLimits := limits.IPv4 - 1
+
+		// Include the primary IP when UsePrimaryAddress is set to true on ENI spec.
+		if n.k8sObj.Spec.ENI.UsePrimaryAddress != nil && *n.k8sObj.Spec.ENI.UsePrimaryAddress {
+			effectiveLimits++
+		}
+		if n.node.Ops().IsPrefixDelegated() {
+			effectiveLimits = effectiveLimits * option.ENIPDBlockSizeIPv4
+		}
+
+		availableOnENI := math.IntMax(effectiveLimits-len(e.Addresses), 0)
 		if availableOnENI <= 0 {
 			continue
 		} else {
@@ -679,6 +685,10 @@ func (n *Node) IsPrefixDelegated() bool {
 			continue
 		}
 		if len(eni.Prefixes) == 0 && len(eni.Addresses) > 0 {
+			// Ignore primary IP of the ENI
+			if len(eni.Addresses) == 1 && eni.Addresses[0] == eni.IP {
+				continue
+			}
 			return false
 		}
 	}

--- a/pkg/aws/eni/types/types.go
+++ b/pkg/aws/eni/types/types.go
@@ -120,6 +120,12 @@ type ENISpec struct {
 	//
 	// +kubebuilder:validation:Optional
 	DeleteOnTermination *bool `json:"delete-on-termination,omitempty"`
+
+	// UsePrimaryAddress determines whether an ENI's primary address
+	// should be available for allocations on the node
+	//
+	// +kubebuilder:validation:Optional
+	UsePrimaryAddress *bool `json:"use-primary-address,omitempty"`
 }
 
 // ENI represents an AWS Elastic Network Interface

--- a/pkg/aws/eni/types/zz_generated.deepcopy.go
+++ b/pkg/aws/eni/types/zz_generated.deepcopy.go
@@ -120,6 +120,11 @@ func (in *ENISpec) DeepCopyInto(out *ENISpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.UsePrimaryAddress != nil {
+		in, out := &in.UsePrimaryAddress, &out.UsePrimaryAddress
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/aws/eni/types/zz_generated.deepequal.go
+++ b/pkg/aws/eni/types/zz_generated.deepequal.go
@@ -258,6 +258,14 @@ func (in *ENISpec) DeepEqual(other *ENISpec) bool {
 		}
 	}
 
+	if (in.UsePrimaryAddress == nil) != (other.UsePrimaryAddress == nil) {
+		return false
+	} else if in.UsePrimaryAddress != nil {
+		if *in.UsePrimaryAddress != *other.UsePrimaryAddress {
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -347,6 +347,10 @@ const (
 	// CiliumNode.Spec.ENI.FirstInterfaceIndex if no value is set.
 	ENIFirstInterfaceIndex = 0
 
+	// UseENIPrimaryAddress is the default value for
+	// CiliumNode.Spec.ENI.UsePrimaryAddress if no value is set.
+	UseENIPrimaryAddress = false
+
 	// ParallelAllocWorkers is the default max number of parallel workers doing allocation in the operator
 	ParallelAllocWorkers = 50
 

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -55,7 +55,10 @@ func (a *AllocatorAWS) Init(ctx context.Context) error {
 	} else {
 		aMetrics = &apiMetrics.NoOpMetrics{}
 	}
-	a.client = ec2shim.NewClient(ec2.NewFromConfig(cfg), aMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst, subnetsFilters, operatorOption.Config.ENITags)
+
+	a.client = ec2shim.NewClient(ec2.NewFromConfig(cfg), aMetrics, operatorOption.Config.IPAMAPIQPSLimit,
+		operatorOption.Config.IPAMAPIBurst, subnetsFilters, operatorOption.Config.ENITags,
+		operatorOption.Config.AWSUsePrimaryAddress)
 
 	if err := limits.UpdateFromUserDefinedMappings(operatorOption.Config.AWSInstanceLimitMapping); err != nil {
 		return fmt.Errorf("failed to parse aws-instance-limit-mapping: %w", err)

--- a/pkg/ipam/crd_eni.go
+++ b/pkg/ipam/crd_eni.go
@@ -22,19 +22,21 @@ import (
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/defaults"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/sirupsen/logrus"
 
+	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
 
 type eniDeviceConfig struct {
-	name string
-	ip   net.IP
-	cidr *net.IPNet
-	mtu  int
+	name         string
+	ip           net.IP
+	cidr         *net.IPNet
+	mtu          int
+	usePrimaryIP bool
 }
 
 type configMap map[string]eniDeviceConfig // by MAC addr
@@ -50,13 +52,19 @@ func configureENIDevices(oldNode, newNode *ciliumv2.CiliumNode, mtuConfig MtuCon
 		existingENIByName = oldNode.Status.ENI.ENIs
 	}
 	firstInterfaceIndex := *newNode.Spec.ENI.FirstInterfaceIndex
+
+	usePrimary := defaults.UseENIPrimaryAddress
+	if newNode.Spec.ENI.UsePrimaryAddress != nil {
+		usePrimary = *newNode.Spec.ENI.UsePrimaryAddress
+	}
+
 	for name, eni := range newNode.Status.ENI.ENIs {
 		if eni.Number < firstInterfaceIndex {
 			continue
 		}
 
 		if _, ok := existingENIByName[name]; !ok {
-			cfg, err := parseENIConfig(name, &eni, mtuConfig)
+			cfg, err := parseENIConfig(name, &eni, mtuConfig, usePrimary)
 			if err != nil {
 				log.WithError(err).
 					WithField(logfields.Resource, name).
@@ -110,7 +118,7 @@ func setupENIDevices(eniConfigByMac configMap) {
 	}
 }
 
-func parseENIConfig(name string, eni *eniTypes.ENI, mtuConfig MtuConfiguration) (cfg eniDeviceConfig, err error) {
+func parseENIConfig(name string, eni *eniTypes.ENI, mtuConfig MtuConfiguration, usePrimary bool) (cfg eniDeviceConfig, err error) {
 	ip := net.ParseIP(eni.IP)
 	if ip == nil {
 		return cfg, fmt.Errorf("failed to parse eni primary ip %q", eni.IP)
@@ -122,10 +130,11 @@ func parseENIConfig(name string, eni *eniTypes.ENI, mtuConfig MtuConfiguration) 
 	}
 
 	return eniDeviceConfig{
-		name: name,
-		ip:   ip,
-		cidr: cidr,
-		mtu:  mtuConfig.GetDeviceMTU(),
+		name:         name,
+		ip:           ip,
+		cidr:         cidr,
+		mtu:          mtuConfig.GetDeviceMTU(),
+		usePrimaryIP: usePrimary,
 	}, nil
 }
 
@@ -177,27 +186,29 @@ func configureENINetlinkDevice(link netlink.Link, cfg eniDeviceConfig) error {
 	}
 
 	// Set the primary IP in order for SNAT to work correctly on this ENI
-	err := netlink.AddrAdd(link, &netlink.Addr{
-		IPNet: &net.IPNet{
-			IP:   cfg.ip,
-			Mask: cfg.cidr.Mask,
-		},
-	})
-	if err != nil && !errors.Is(err, unix.EEXIST) {
-		return fmt.Errorf("failed to set eni primary ip address %q on link %q: %w", cfg.ip, link.Attrs().Name, err)
-	}
+	if !cfg.usePrimaryIP {
+		err := netlink.AddrAdd(link, &netlink.Addr{
+			IPNet: &net.IPNet{
+				IP:   cfg.ip,
+				Mask: cfg.cidr.Mask,
+			},
+		})
+		if err != nil && !errors.Is(err, unix.EEXIST) {
+			return fmt.Errorf("failed to set eni primary ip address %q on link %q: %w", cfg.ip, link.Attrs().Name, err)
+		}
 
-	// Remove the default route for this ENI, as it can overlap with the
-	// default route of the primary ENI and therefore break node connectivity
-	err = netlink.RouteDel(&netlink.Route{
-		Dst:   cfg.cidr,
-		Src:   cfg.ip,
-		Table: unix.RT_TABLE_MAIN,
-		Scope: netlink.SCOPE_LINK,
-	})
-	if err != nil && !errors.Is(err, unix.ESRCH) {
-		// We ignore ESRCH, as it means the entry was already deleted
-		return fmt.Errorf("failed to delete default route %q on link %q: %w", cfg.ip, link.Attrs().Name, err)
+		// Remove the default route for this ENI, as it can overlap with the
+		// default route of the primary ENI and therefore break node connectivity
+		err = netlink.RouteDel(&netlink.Route{
+			Dst:   cfg.cidr,
+			Src:   cfg.ip,
+			Table: unix.RT_TABLE_MAIN,
+			Scope: netlink.SCOPE_LINK,
+		})
+		if err != nil && !errors.Is(err, unix.ESRCH) {
+			// We ignore ESRCH, as it means the entry was already deleted
+			return fmt.Errorf("failed to delete default route %q on link %q: %w", cfg.ip, link.Attrs().Name, err)
+		}
 	}
 
 	return nil

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -185,6 +185,10 @@ spec:
                     description: SubnetTags is the list of tags to use when evaluating
                       what AWS subnets to use for ENI and IP allocation.
                     type: object
+                  use-primary-address:
+                    description: UsePrimaryAddress determines whether an ENI's primary
+                      address should be available for allocations on the node
+                    type: boolean
                   vpc-id:
                     description: VpcID is the VPC ID to use when allocating ENIs.
                     type: string

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -490,6 +490,7 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 		// determine the appropriate value to place inside the resource.
 		nodeResource.Spec.ENI.VpcID = vpcID
 		nodeResource.Spec.ENI.FirstInterfaceIndex = getInt(defaults.ENIFirstInterfaceIndex)
+		nodeResource.Spec.ENI.UsePrimaryAddress = getBool(defaults.UseENIPrimaryAddress)
 
 		if c := n.NetConf; c != nil {
 			if c.IPAM.MinAllocate != 0 {
@@ -526,6 +527,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 
 			if c.ENI.VpcID != "" {
 				nodeResource.Spec.ENI.VpcID = c.ENI.VpcID
+			}
+
+			if c.ENI.UsePrimaryAddress != nil {
+				nodeResource.Spec.ENI.UsePrimaryAddress = c.ENI.UsePrimaryAddress
 			}
 
 			nodeResource.Spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination
@@ -636,4 +641,24 @@ func (n *NodeDiscovery) RegisterK8sNodeGetter(k8sNodeGetter k8sNodeGetter) {
 
 func getInt(i int) *int {
 	return &i
+}
+
+func getBool(b bool) *bool {
+	return &b
+}
+
+func (nodeDiscovery *NodeDiscovery) UpdateKVNodeEntry(node *nodeTypes.Node) error {
+	if nodeDiscovery.Registrar.SharedStore == nil {
+		return nil
+	}
+
+	if err := nodeDiscovery.Registrar.UpdateLocalKeySync(node); err != nil {
+		return fmt.Errorf("failed to update KV node store entry: %w", err)
+	}
+
+	if err := nodeDiscovery.mutateNodeResource(node.ToCiliumNode()); err != nil {
+		return fmt.Errorf("failed to mutate node resource: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/20050 to cilium 1.10

Recently ENI's primary IP has been removed from pool of IPs available
for allocations on the node. This has been done to make sure SNAT works
correctly when kube-proxy is used. See https://github.com/cilium/cilium/commit/bc0a748021f5234880fdede51cf04e4fe6d1833b
for more details. However this can lead to IP wastage in large clusters.
The SNAT case does not apply when cilium runs in kube proxy replacement
mode.

This commit adds a new flag called --aws-use-primary-address to the
operator and new field in ciliumnode CRD ENI spec called
UseENIPrimaryAddress to opt in for using the ENI primary address. Azure
IPAM mode already has a flag like this.

Signed-off-by: Hemanth Malla <hemanth.malla@datadoghq.com>
