### PR TITLE
Add support for disabling ENI PD at node level

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/math"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/smithy-go"
 	"github.com/sirupsen/logrus"
 )
@@ -676,6 +677,10 @@ func (n *Node) IsPrefixDelegated() bool {
 	}
 	// Allocating prefixes is supported only on nitro instances
 	if limits.HypervisorType != "nitro" {
+		return false
+	}
+	// Check if this node is allowed to use prefix delegation
+	if n.k8sObj.Spec.ENI.DisablePrefixDelegation != nil && aws.ToBool(n.k8sObj.Spec.ENI.DisablePrefixDelegation) {
 		return false
 	}
 	// Verify if all interfaces are prefix delegated. We don't want to enable prefix delegation on nodes that already

--- a/pkg/aws/eni/types/types.go
+++ b/pkg/aws/eni/types/types.go
@@ -126,6 +126,12 @@ type ENISpec struct {
 	//
 	// +kubebuilder:validation:Optional
 	UsePrimaryAddress *bool `json:"use-primary-address,omitempty"`
+
+	// DisablePrefixDelegation determines whether ENI prefix delegation should be
+	// disabled on this node.
+	//
+	// +kubebuilder:validation:Optional
+	DisablePrefixDelegation *bool `json:"disable-prefix-delegation,omitempty"`
 }
 
 // ENI represents an AWS Elastic Network Interface

--- a/pkg/aws/eni/types/zz_generated.deepcopy.go
+++ b/pkg/aws/eni/types/zz_generated.deepcopy.go
@@ -125,6 +125,11 @@ func (in *ENISpec) DeepCopyInto(out *ENISpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisablePrefixDelegation != nil {
+		in, out := &in.DisablePrefixDelegation, &out.DisablePrefixDelegation
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/aws/eni/types/zz_generated.deepequal.go
+++ b/pkg/aws/eni/types/zz_generated.deepequal.go
@@ -266,6 +266,14 @@ func (in *ENISpec) DeepEqual(other *ENISpec) bool {
 		}
 	}
 
+	if (in.DisablePrefixDelegation == nil) != (other.DisablePrefixDelegation == nil) {
+		return false
+	} else if in.DisablePrefixDelegation != nil {
+		if *in.DisablePrefixDelegation != *other.DisablePrefixDelegation {
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -351,6 +351,10 @@ const (
 	// CiliumNode.Spec.ENI.UsePrimaryAddress if no value is set.
 	UseENIPrimaryAddress = false
 
+	// ENIDisableNodeLevelPD  is the default value for
+	// CiliumNode.Spec.ENI.DisablePrefixDelegation if no value is set.
+	ENIDisableNodeLevelPD = false
+
 	// ParallelAllocWorkers is the default max number of parallel workers doing allocation in the operator
 	ParallelAllocWorkers = 50
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -124,6 +124,10 @@ spec:
                       is not set the default behavior is to delete the ENI on instance
                       termination.
                     type: boolean
+                  disable-prefix-delegation:
+                    description: DisablePrefixDelegation determines whether ENI prefix
+                      delegation should be disabled on this node.
+                    type: boolean
                   first-interface-index:
                     description: FirstInterfaceIndex is the index of the first ENI
                       to use for IP allocation, e.g. if the node has eth0, eth1, eth2

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -34,7 +34,7 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.23.4"
+	CustomResourceDefinitionSchemaVersion = "1.23.5"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -491,6 +491,7 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 		nodeResource.Spec.ENI.VpcID = vpcID
 		nodeResource.Spec.ENI.FirstInterfaceIndex = getInt(defaults.ENIFirstInterfaceIndex)
 		nodeResource.Spec.ENI.UsePrimaryAddress = getBool(defaults.UseENIPrimaryAddress)
+		nodeResource.Spec.ENI.DisablePrefixDelegation = getBool(defaults.ENIDisableNodeLevelPD)
 
 		if c := n.NetConf; c != nil {
 			if c.IPAM.MinAllocate != 0 {
@@ -531,6 +532,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 
 			if c.ENI.UsePrimaryAddress != nil {
 				nodeResource.Spec.ENI.UsePrimaryAddress = c.ENI.UsePrimaryAddress
+			}
+
+			if c.ENI.DisablePrefixDelegation != nil {
+				nodeResource.Spec.ENI.DisablePrefixDelegation = c.ENI.DisablePrefixDelegation
 			}
 
 			nodeResource.Spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/20308 with the following modifications :
* CRD version bumped from `1.23.4` to `1.23.5`
* Exclude interface tags addition to CN CRD spec removed, since the feature isn't in `1.10` yet.
