### PR TITLE
1.10 backport : iptables: skip NOTRACK rules deletion

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -234,6 +234,17 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 			continue
 		}
 
+		// Temporary fix while Iptables is upgraded to >= 1.8.5
+		// (See GH-20884).
+		//
+		// The version currently shipped with Cilium (1.8.4) does not
+		// support the deletion of NOTRACK rules, so we will just ignore
+		// them here and let the agent remove them when it deletes the
+		// entire chain.
+		if strings.Contains(rule, "-j NOTRACK") {
+			continue
+		}
+
 		// do not remove feeder for chains that are set to be disabled
 		// ie catch the beginning of the rule like -A POSTROUTING to match it against
 		// disabled chains


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/20885 

The Iptables version shipped with Cilium (1.8.4) does not fully support
the iptables-legacy - nft translation of NOTRACK rules, which in turn
causes the agent to crash whenever it tries to delete any old/backup
ruleset.

This commit introduces a workaround for this by ignoring the `-j
NOTRACK` and `-j CT --notrack` rules when deleting all rules belonging
to an old/backup ruleset.

This is not an issue (although it's not optimal) as eventually the agent
will just flush and remove all the Cilium managed Iptables chains.

Signed-off-by: Gilberto Bertin <jibi@cilium.io>
