### PR TITLE
policy: Fix transient policy deny during restart due to missing ipcache

### DIFF
--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -289,10 +289,13 @@ func (e *Endpoint) restoreIdentity() error {
 			return ErrNotAlive
 		case <-gotInitialGlobalIdentities:
 		}
+	}
 
-		if option.Config.KVStore != "" {
-			ipcache.WaitForKVStoreSync()
-		}
+	// Wait for ipcache sync before regeneration for endpoints including
+	// the ones with fixed identity (e.g. host endpoint), this ensures that
+	// the regenerated datapath always lookups from a ready ipcache map.
+	if option.Config.KVStore != "" {
+		ipcache.WaitForKVStoreSync()
 	}
 
 	if err := e.lockAlive(); err != nil {


### PR DESCRIPTION
Currently, during endpoint restoration, ipcache map is unpinned and recreated by Map.OpenParallel, regenerated endpoints lookup from the newly created ipcache map, so the regeneration of endpoints should wait for the ipcache map to be synchronized. However, the regeneration of host endpoint doesn't wait for ipcache map sync, which introduces transient policy deny.

This patch fixes this by making all endpoints wait for ipcache map sync.

Fixes: #15878
Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
