### PR TITLE
eni: Don't restore the connmark when Cilium is carrying the identity

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1447,6 +1447,7 @@ func (m *IptablesManager) addCiliumENIRules() error {
 
 	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
 	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
+	identityMarkMask := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIdentity, linux_defaults.MagicMarkHostMask)
 
 	// Note: these rules need the xt_connmark module (iptables usually
 	// loads it when required, unless loading modules after boot has been
@@ -1466,5 +1467,12 @@ func (m *IptablesManager) addCiliumENIRules() error {
 		"-A", ciliumPreMangleChain,
 		"-i", "lxc+",
 		"-m", "comment", "--comment", "cilium: primary ENI",
+		// Don't restore the mark when we are carrying the identity with mark,
+		// because we are using 7th bit to carry the uppermost bit of the identity
+		// and it is overlapping with ENI's mark. Below --restore-mark "restores"
+		// the connmark and it zeros the 7th bit when connmark is zero. As a result,
+		// identity will be changed. This will become a problem only when we are
+		// setting the ClusterID 128-255.
+		"-m", "mark", "!", "--mark", identityMarkMask,
 		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask})
 }

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -154,8 +154,10 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing datapath.NodeAddre
 	if err := route.ReplaceRule(route.Rule{
 		Priority: linux_defaults.RulePriorityNodeport,
 		Mark:     linux_defaults.MarkMultinodeNodeport,
-		Mask:     linux_defaults.MaskMultinodeNodeport,
-		Table:    route.MainTable,
+		// Avoid selecting this rule when we're carrying identity with mark. See corresponding primary ENI iptables rule
+		// to restore connmark for more details
+		Mask:  linux_defaults.MagicMarkIdentity | linux_defaults.MaskMultinodeNodeport,
+		Table: route.MainTable,
 	}); err != nil {
 		return nil, fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
 	}


### PR DESCRIPTION
ENI CNI uses the 7th bit (0x80/0x80) of the mark for PBR. Cilium also uses 7th bit to carry the upper most bit of the security identity in some cases (e.g. Pod to Pod communication on the same node). ENI CNI uses CONNMARK iptables target to record the flow came from the external network and restores it in the reply path.

When ENI "restores" the mark for the new connection (connmark == 0), it zeros the 7th bit of the mark and changes the identity. This becomes the problem when Cilium is carrying the identity and the upper most bit is 1. The upper most bit becomes 1 when the ClusterID of the source endpoint is 128-255 since we are encoding ClusterID into the upper most 8bits of the identity.

There are two possible iptables rules which causes this error.

1. The rule in the CILIUM_PRE_mangle chain (managed by us, introduced in #12770)

```
-A CILIUM_PRE_mangle -i lxc+ -m comment --comment "cilium: primary ENI" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
```

2. The rule in the PREROUTING chain of nat table (managed by AWS)

```
-A PREROUTING -m comment --comment "AWS, CONNMARK" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
```

There are three possible setup affected by this issue

1. Cilium is running with ENI mode after uninstalling AWS VPC CNI (e.g. create EKS cluster and install Cilium after that)
2. Cilium is running with AWS VPC CNI with chaining mode
3. Cilium is running with ENI mode without AWS VPC CNI from the beginning (e.g. self-hosted k8s cluster on EC2 hosts)

In setup 3, we can fix the issue by only modifying rule 1. This is what this commit focuses on. It can be resolved by adding the matching rule that don't restore the connmark when we are carrying the mark. We can check if the MARK_MAGIC_IDENTITY is set.

```
-A CILIUM_PRE_mangle -i lxc+ -m comment --comment "cilium: primary ENI" -m mark ! --mark 0x0F00/0x0F00 -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
```

Corresponding IP rule to lookup the main routing table based on mark value of 0x80 has also been updated to account for this exclusion.

Co-developed-by: Yutaro Hayakawa <yutaro.hayakawa@isovalent.com>
Co-developed-by: Hemanth Malla <hemanth.malla@datadoghq.com>
Suggested-by: Eric Mountain <eric.mountain@datadoghq.com>
Signed-off-by: Yutaro Hayakawa <yutaro.hayakawa@isovalent.com>
Signed-off-by: Hemanth Malla <hemanth.malla@datadoghq.com>
