### PR TITLE
Include mask value while looking up ip rule

### DIFF
--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -387,6 +387,10 @@ func lookupRule(spec Rule, family int) (bool, error) {
 			continue
 		}
 
+		if spec.Mask != 0 && r.Mask != spec.Mask {
+			continue
+		}
+
 		if r.Table == spec.Table {
 			return true, nil
 		}


### PR DESCRIPTION
Currently mask value is not included while looking up existing IP rules. If an existing IP rule has an update only in it's mask, the rule would never be replaced.
