### PR TITLE
Clean up old ENI multi nodeport IP rule

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -151,6 +151,19 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing datapath.NodeAddre
 		Val:       "2",
 		IgnoreErr: false,
 	})
+	// Delete old nodeport rule if it exists
+	oldRule := route.Rule{
+		Priority: linux_defaults.RulePriorityNodeport,
+		Mark:     linux_defaults.MarkMultinodeNodeport,
+		Mask:     linux_defaults.MaskMultinodeNodeport,
+		Table:    route.MainTable,
+	}
+	if err := route.DeleteRule(oldRule); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("unable to delete old ip rule for ENI multi-node NodePort: %w", err)
+		}
+	}
+	// Install updated ip rule for ENI multi-node NodePort
 	if err := route.ReplaceRule(route.Rule{
 		Priority: linux_defaults.RulePriorityNodeport,
 		Mark:     linux_defaults.MarkMultinodeNodeport,


### PR DESCRIPTION
Clean up old ENI multi nodeport IP rule before installing the new one
