### PR TITLE
Benhinthorne/cherrypick clusterid128 fix

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1571,6 +1571,7 @@ func (m *IptablesManager) addCiliumENIRules() error {
 
 	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
 	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
+	identityMarkMask := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIdentity, linux_defaults.MagicMarkHostMask)
 
 	// Note: these rules need the xt_connmark module (iptables usually
 	// loads it when required, unless loading modules after boot has been
@@ -1590,5 +1591,12 @@ func (m *IptablesManager) addCiliumENIRules() error {
 		"-A", ciliumPreMangleChain,
 		"-i", "lxc+",
 		"-m", "comment", "--comment", "cilium: primary ENI",
+		// Don't restore the mark when we are carrying the identity with mark,
+		// because we are using 7th bit to carry the uppermost bit of the identity
+		// and it is overlapping with ENI's mark. Below --restore-mark "restores"
+		// the connmark and it zeros the 7th bit when connmark is zero. As a result,
+		// identity will be changed. This will become a problem only when we are
+		// setting the ClusterID 128-255.
+		"-m", "mark", "!", "--mark", identityMarkMask,
 		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask})
 }

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -379,6 +379,10 @@ func lookupRule(spec Rule, family int) (bool, error) {
 			continue
 		}
 
+		if spec.Mask != 0 && r.Mask != spec.Mask {
+			continue
+		}
+
 		if r.Table == spec.Table {
 			return true, nil
 		}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -141,6 +141,19 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing datapath.NodeAddre
 		Val:       "2",
 		IgnoreErr: false,
 	})
+	// Delete old nodeport rule if it exists
+	oldRule := route.Rule{
+		Priority: linux_defaults.RulePriorityNodeport,
+		Mark:     linux_defaults.MarkMultinodeNodeport,
+		Mask:     linux_defaults.MaskMultinodeNodeport,
+		Table:    route.MainTable,
+	}
+	if err := route.DeleteRule(oldRule); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("unable to delete old ip rule for ENI multi-node NodePort: %w", err)
+		}
+	}
+	// Install updated ip rule for ENI multi-node NodePort
 	if err := route.ReplaceRule(route.Rule{
 		Priority: linux_defaults.RulePriorityNodeport,
 		Mark:     linux_defaults.MarkMultinodeNodeport,

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -144,8 +144,10 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing datapath.NodeAddre
 	if err := route.ReplaceRule(route.Rule{
 		Priority: linux_defaults.RulePriorityNodeport,
 		Mark:     linux_defaults.MarkMultinodeNodeport,
-		Mask:     linux_defaults.MaskMultinodeNodeport,
-		Table:    route.MainTable,
+		// Avoid selecting this rule when we're carrying identity with mark. See corresponding primary ENI iptables rule
+		// to restore connmark for more details
+		Mask:  linux_defaults.MagicMarkIdentity | linux_defaults.MaskMultinodeNodeport,
+		Table: route.MainTable,
 	}); err != nil {
 		return nil, fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
 	}


### PR DESCRIPTION
This PR cherry-picks the following commits in order to backport the cluster_id 128 fix into our 1.11-dd cilium version:
- https://github.com/cilium/cilium/pull/23049/commits/a399aeb1b552ca91da7ab9c0936c358baf0bad8e
- https://github.com/cilium/cilium/pull/23049/commits/308a7a7605290f01084d03046e9004b230fafa5e
- https://github.com/cilium/cilium/pull/23049/commits/7e665ca5fbaa585c44b21395ea51f36ae535a18c

I tested building both the agent and operator images before merging in these pipelines:
- https://gitlab.ddbuild.io/DataDog/images/-/pipelines/12648104
- https://gitlab.ddbuild.io/DataDog/images/-/pipelines/12648330

Note that this change should only affect the agent, but we will also build a new operator image in order to keep version consistency across the agent and operator.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
