### PR TITLE
service: Improve memory usage when handling update of a big service.

### DIFF
--- a/daemon/cmd/loadbalancer.go
+++ b/daemon/cmd/loadbalancer.go
@@ -40,13 +40,13 @@ func (h *putServiceID) Handle(params PutServiceIDParams) middleware.Responder {
 		L3n4Addr: *f,
 		ID:       loadbalancer.ID(params.Config.ID),
 	}
-	backends := []loadbalancer.Backend{}
+	backends := []*loadbalancer.Backend{}
 	for _, v := range params.Config.BackendAddresses {
 		b, err := loadbalancer.NewBackendFromBackendModel(v)
 		if err != nil {
 			return api.Error(PutServiceIDInvalidBackendCode, err)
 		}
-		backends = append(backends, *b)
+		backends = append(backends, b)
 	}
 
 	var svcType loadbalancer.SVCType

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -499,8 +499,8 @@ func (k *K8sWatcher) genServiceMappings(pod *slim_corev1.Pod, podIPs []string, l
 				continue
 			}
 
-			var bes4 []loadbalancer.Backend
-			var bes6 []loadbalancer.Backend
+			var bes4 []*loadbalancer.Backend
+			var bes6 []*loadbalancer.Backend
 
 			for _, podIP := range podIPs {
 				be := loadbalancer.Backend{
@@ -513,9 +513,9 @@ func (k *K8sWatcher) genServiceMappings(pod *slim_corev1.Pod, podIPs []string, l
 					},
 				}
 				if be.L3n4Addr.IP.To4() != nil {
-					bes4 = append(bes4, be)
+					bes4 = append(bes4, &be)
 				} else {
-					bes6 = append(bes6, be)
+					bes6 = append(bes6, &be)
 				}
 			}
 
@@ -860,8 +860,8 @@ func (k *K8sWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 // agent flag `option.Config.K8sEventHandover` this function might only return
 // local pods.
 // If `option.Config.K8sEventHandover` is:
-//  - true: returns only local pods received by the pod watcher.
-//  - false: returns any pod in the cluster received by the pod watcher.
+//   - true: returns only local pods received by the pod watcher.
+//   - false: returns any pod in the cluster received by the pod watcher.
 func (k *K8sWatcher) GetCachedPod(namespace, name string) (*slim_corev1.Pod, error) {
 	<-k.controllersStarted
 	k.WaitForCacheSync(K8sAPIGroupPodV1Core)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -627,12 +627,12 @@ func genCartesianProduct(
 	feFamilyIPv6 := ip.IsIPv6(fe)
 
 	for fePortName, fePort := range ports {
-		var besValues []loadbalancer.Backend
+		var besValues []*loadbalancer.Backend
 		for netIP, backend := range bes.Backends {
 			parsedIP := net.ParseIP(netIP)
 
 			if backendPort := backend.Ports[string(fePortName)]; backendPort != nil && feFamilyIPv6 == ip.IsIPv6(parsedIP) {
-				besValues = append(besValues, loadbalancer.Backend{
+				besValues = append(besValues, &loadbalancer.Backend{
 					NodeName: backend.NodeName,
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP:     parsedIP,

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -344,7 +344,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		lb1.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *lb1,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -362,7 +362,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		// lb2.Hash(): {
 		// 	Type:     loadbalancer.SVCTypeClusterIP,
 		// 	Frontend: *lb2,
-		// 	Backends: []loadbalancer.Backend{
+		// 	Backends: []*loadbalancer.Backend{
 		// 		{
 		// 			L3n4Addr: loadbalancer.L3n4Addr{
 		// 				IP: net.ParseIP("2.2.2.2"),
@@ -377,7 +377,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		lb3.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *lb3,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -401,7 +401,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		lb1.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *lb1,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -428,7 +428,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		// lb2.Hash(): {
 		// 	Type:     loadbalancer.SVCTypeClusterIP,
 		// 	Frontend: *lb2,
-		// 	Backends: []loadbalancer.Backend{
+		// 	Backends: []*loadbalancer.Backend{
 		// 		{
 		// 			L3n4Addr: loadbalancer.L3n4Addr{
 		// 				IP: net.ParseIP("2.2.2.2"),
@@ -452,7 +452,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		lb3.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *lb3,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -610,7 +610,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		{
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *lb1,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -625,7 +625,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		{
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *lb2,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -787,7 +787,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		clusterIP1.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP1,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -805,7 +805,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		// clusterIP2.Hash(): {
 		// 	Type:     loadbalancer.SVCTypeClusterIP,
 		// 	Frontend: *clusterIP2,
-		// 	Backends: []loadbalancer.Backend{
+		// 	Backends: []*loadbalancer.Backend{
 		// 		{
 		// 			L3n4Addr: loadbalancer.L3n4Addr{
 		// 				IP: net.ParseIP("2.2.2.2"),
@@ -820,7 +820,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		clusterIP3.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP3,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -843,7 +843,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		upsert1stWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -865,7 +865,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 	// 	upsert1stWanted[nodePort.Hash()] = loadbalancer.SVC{
 	// 		Type:     loadbalancer.SVCTypeNodePort,
 	// 		Frontend: *nodePort,
-	// 		Backends: []loadbalancer.Backend{
+	// 		Backends: []*loadbalancer.Backend{
 	// 			{
 	// 				L3n4Addr: loadbalancer.L3n4Addr{
 	// 					IP: net.ParseIP("2.2.2.2"),
@@ -887,7 +887,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		upsert1stWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -911,7 +911,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		clusterIP1.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP1,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -938,7 +938,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		// clusterIP2.Hash(): {
 		// 	Type:     loadbalancer.SVCTypeClusterIP,
 		// 	Frontend: *clusterIP2,
-		// 	Backends: []loadbalancer.Backend{
+		// 	Backends: []*loadbalancer.Backend{
 		// 		{
 		// 			L3n4Addr: loadbalancer.L3n4Addr{
 		// 				IP: net.ParseIP("2.2.2.2"),
@@ -962,7 +962,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		clusterIP3.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP3,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -989,7 +989,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		upsert2ndWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1015,7 +1015,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 	// 	upsert2ndWanted[nodePort.Hash()] = loadbalancer.SVC{
 	// 		Type:     loadbalancer.SVCTypeNodePort,
 	// 		Frontend: *nodePort,
-	// 		Backends: []loadbalancer.Backend{
+	// 		Backends: []*loadbalancer.Backend{
 	// 			{
 	// 				L3n4Addr: loadbalancer.L3n4Addr{
 	// 					IP: net.ParseIP("2.2.2.2"),
@@ -1041,7 +1041,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		upsert2ndWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1262,7 +1262,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		clusterIP1.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP1,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1277,7 +1277,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		clusterIP2.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP2,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1294,7 +1294,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		upsert1stWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1311,7 +1311,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		upsert1stWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1331,7 +1331,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		clusterIP2.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP2,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1346,7 +1346,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		clusterIP3.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP3,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1547,7 +1547,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		clusterIP1.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP1,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1562,7 +1562,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		clusterIP2.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP2,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1579,7 +1579,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		upsert1stWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1596,7 +1596,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		upsert1stWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1614,7 +1614,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		clusterIP1.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP1,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("3.3.3.3"),
@@ -1635,7 +1635,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		upsert2ndWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("3.3.3.3"),
@@ -1835,7 +1835,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		clusterIP1.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP1,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1853,7 +1853,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		// clusterIP2.Hash(): {
 		// 	Type:     loadbalancer.SVCTypeClusterIP,
 		// 	Frontend: *clusterIP2,
-		// 	Backends: []loadbalancer.Backend{
+		// 	Backends: []*loadbalancer.Backend{
 		// 		{
 		// 			L3n4Addr: loadbalancer.L3n4Addr{
 		// 				IP: net.ParseIP("2.2.2.2"),
@@ -1868,7 +1868,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		clusterIP3.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP3,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1892,7 +1892,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert1stWanted[externalIP.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeExternalIPs,
 			Frontend: *externalIP,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1909,7 +1909,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 	// 	upsert1stWanted[externalIP.Hash()] = loadbalancer.SVC{
 	// 		Type:     loadbalancer.SVCTypeExternalIPs,
 	// 		Frontend: *externalIP,
-	// 		Backends: []loadbalancer.Backend{
+	// 		Backends: []*loadbalancer.Backend{
 	// 			{
 	// 				L3n4Addr: loadbalancer.L3n4Addr{
 	// 					IP: net.ParseIP("2.2.2.2"),
@@ -1926,7 +1926,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert1stWanted[externalIP.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeExternalIPs,
 			Frontend: *externalIP,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1949,7 +1949,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert1stWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -1971,7 +1971,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 	// 	upsert1stWanted[nodePort.Hash()] = loadbalancer.SVC{
 	// 		Type:     loadbalancer.SVCTypeNodePort,
 	// 		Frontend: *nodePort,
-	// 		Backends: []loadbalancer.Backend{
+	// 		Backends: []*loadbalancer.Backend{
 	// 			{
 	// 				L3n4Addr: loadbalancer.L3n4Addr{
 	// 					IP: net.ParseIP("2.2.2.2"),
@@ -1993,7 +1993,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert1stWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2011,7 +2011,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		clusterIP1.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP1,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2038,7 +2038,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		// clusterIP2.Hash(): {
 		// 	Type:     loadbalancer.SVCTypeClusterIP,
 		// 	Frontend: *clusterIP2,
-		// 	Backends: []loadbalancer.Backend{
+		// 	Backends: []*loadbalancer.Backend{
 		// 		{
 		// 			L3n4Addr: loadbalancer.L3n4Addr{
 		// 				IP: net.ParseIP("2.2.2.2"),
@@ -2062,7 +2062,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		clusterIP3.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP3,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2089,7 +2089,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert2ndWanted[externalIP.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeExternalIPs,
 			Frontend: *externalIP,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2115,7 +2115,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 	// 	upsert2ndWanted[externalIP.Hash()] = loadbalancer.SVC{
 	// 		Type:     loadbalancer.SVCTypeExternalIPs,
 	// 		Frontend: *externalIP,
-	// 		Backends: []loadbalancer.Backend{
+	// 		Backends: []*loadbalancer.Backend{
 	// 			{
 	// 				L3n4Addr: loadbalancer.L3n4Addr{
 	// 					IP: net.ParseIP("2.2.2.2"),
@@ -2141,7 +2141,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert2ndWanted[externalIP.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeExternalIPs,
 			Frontend: *externalIP,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2168,7 +2168,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert2ndWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2194,7 +2194,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 	// 	upsert2ndWanted[nodePort.Hash()] = loadbalancer.SVC{
 	// 		Type:     loadbalancer.SVCTypeNodePort,
 	// 		Frontend: *nodePort,
-	// 		Backends: []loadbalancer.Backend{
+	// 		Backends: []*loadbalancer.Backend{
 	// 			{
 	// 				L3n4Addr: loadbalancer.L3n4Addr{
 	// 					IP: net.ParseIP("2.2.2.2"),
@@ -2220,7 +2220,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert2ndWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2247,7 +2247,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		clusterIP1.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP1,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2274,7 +2274,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		// clusterIP2.Hash(): {
 		// 	Type:     loadbalancer.SVCTypeClusterIP,
 		// 	Frontend: *clusterIP2,
-		// 	Backends: []loadbalancer.Backend{
+		// 	Backends: []*loadbalancer.Backend{
 		// 		{
 		// 			L3n4Addr: loadbalancer.L3n4Addr{
 		// 				IP: net.ParseIP("2.2.2.2"),
@@ -2298,7 +2298,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		clusterIP3.Hash(): {
 			Type:     loadbalancer.SVCTypeClusterIP,
 			Frontend: *clusterIP3,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2325,7 +2325,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert3rdWanted[externalIP.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeExternalIPs,
 			Frontend: *externalIP,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2351,7 +2351,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 	// 	upsert3rdWanted[externalIP.Hash()] = loadbalancer.SVC{
 	// 		Type:     loadbalancer.SVCTypeExternalIPs,
 	// 		Frontend: *externalIP,
-	// 		Backends: []loadbalancer.Backend{
+	// 		Backends: []*loadbalancer.Backend{
 	// 			{
 	// 				L3n4Addr: loadbalancer.L3n4Addr{
 	// 					IP: net.ParseIP("2.2.2.2"),
@@ -2377,7 +2377,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert3rdWanted[externalIP.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeExternalIPs,
 			Frontend: *externalIP,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2404,7 +2404,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert3rdWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),
@@ -2430,7 +2430,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 	// 	upsert3rdWanted[nodePort.Hash()] = loadbalancer.SVC{
 	// 		Type:     loadbalancer.SVCTypeNodePort,
 	// 		Frontend: *nodePort,
-	// 		Backends: []loadbalancer.Backend{
+	// 		Backends: []*loadbalancer.Backend{
 	// 			{
 	// 				L3n4Addr: loadbalancer.L3n4Addr{
 	// 					IP: net.ParseIP("2.2.2.2"),
@@ -2456,7 +2456,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		upsert3rdWanted[nodePort.Hash()] = loadbalancer.SVC{
 			Type:     loadbalancer.SVCTypeNodePort,
 			Frontend: *nodePort,
-			Backends: []loadbalancer.Backend{
+			Backends: []*loadbalancer.Backend{
 				{
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP: net.ParseIP("2.2.2.2"),

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -202,7 +202,7 @@ func (b *Backend) String() string {
 // SVC is a structure for storing service details.
 type SVC struct {
 	Frontend                  L3n4AddrID       // SVC frontend addr and an allocated ID
-	Backends                  []Backend        // List of service backends
+	Backends                  []*Backend       // List of service backends
 	Type                      SVCType          // Service type
 	TrafficPolicy             SVCTrafficPolicy // Service traffic policy
 	SessionAffinity           bool

--- a/pkg/loadbalancer/zz_generated.deepcopy.go
+++ b/pkg/loadbalancer/zz_generated.deepcopy.go
@@ -92,9 +92,13 @@ func (in *SVC) DeepCopyInto(out *SVC) {
 	in.Frontend.DeepCopyInto(&out.Frontend)
 	if in.Backends != nil {
 		in, out := &in.Backends, &out.Backends
-		*out = make([]Backend, len(*in))
+		*out = make([]*Backend, len(*in))
 		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(Backend)
+				(*in).DeepCopyInto(*out)
+			}
 		}
 	}
 	if in.LoadBalancerSourceRanges != nil {

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -588,29 +588,29 @@ func (svcs svcMap) addFEnBE(fe *loadbalancer.L3n4AddrID, be *loadbalancer.Backen
 	hash := fe.Hash()
 	lbsvc, ok := svcs[hash]
 	if !ok {
-		var bes []loadbalancer.Backend
+		var bes []*loadbalancer.Backend
 		if beIndex == 0 {
-			bes = make([]loadbalancer.Backend, 1)
-			bes[0] = *be
+			bes = make([]*loadbalancer.Backend, 1)
+			bes[0] = be
 		} else {
-			bes = make([]loadbalancer.Backend, beIndex)
-			bes[beIndex-1] = *be
+			bes = make([]*loadbalancer.Backend, beIndex)
+			bes[beIndex-1] = be
 		}
 		lbsvc = loadbalancer.SVC{
 			Frontend: *fe,
 			Backends: bes,
 		}
 	} else {
-		var bes []loadbalancer.Backend
+		var bes []*loadbalancer.Backend
 		if len(lbsvc.Backends) < beIndex {
-			bes = make([]loadbalancer.Backend, beIndex)
+			bes = make([]*loadbalancer.Backend, beIndex)
 			copy(bes, lbsvc.Backends)
 			lbsvc.Backends = bes
 		}
 		if beIndex == 0 {
-			lbsvc.Backends = append(lbsvc.Backends, *be)
+			lbsvc.Backends = append(lbsvc.Backends, be)
 		} else {
-			lbsvc.Backends[beIndex-1] = *be
+			lbsvc.Backends[beIndex-1] = be
 		}
 	}
 

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -543,9 +543,9 @@ func (rpm *Manager) upsertService(config *LRPConfig, frontendMapping *feMapping)
 		L3n4Addr: *frontendMapping.feAddr,
 		ID:       lb.ID(0),
 	}
-	backendAddrs := make([]lb.Backend, 0, len(frontendMapping.podBackends))
+	backendAddrs := make([]*lb.Backend, 0, len(frontendMapping.podBackends))
 	for _, be := range frontendMapping.podBackends {
-		backendAddrs = append(backendAddrs, lb.Backend{
+		backendAddrs = append(backendAddrs, &lb.Backend{
 			NodeName: nodeTypes.GetName(),
 			L3n4Addr: be.L3n4Addr,
 		})

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -74,20 +74,20 @@ var (
 	frontend1 = *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.1"), 80, lb.ScopeExternal, 0)
 	frontend2 = *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.2"), 80, lb.ScopeExternal, 0)
 	frontend3 = *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("f00d::1"), 80, lb.ScopeExternal, 0)
-	backends1 = []lb.Backend{
-		*lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.1"), 8080),
-		*lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080),
+	backends1 = []*lb.Backend{
+		lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.1"), 8080),
+		lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080),
 	}
-	backends2 = []lb.Backend{
-		*lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080),
-		*lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.3"), 8080),
+	backends2 = []*lb.Backend{
+		lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080),
+		lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.3"), 8080),
 	}
-	backends3 = []lb.Backend{
-		*lb.NewBackend(0, lb.TCP, net.ParseIP("fd00::2"), 8080),
-		*lb.NewBackend(0, lb.TCP, net.ParseIP("fd00::3"), 8080),
+	backends3 = []*lb.Backend{
+		lb.NewBackend(0, lb.TCP, net.ParseIP("fd00::2"), 8080),
+		lb.NewBackend(0, lb.TCP, net.ParseIP("fd00::3"), 8080),
 	}
-	backends4 = []lb.Backend{
-		*lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.4"), 8080),
+	backends4 = []*lb.Backend{
+		lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.4"), 8080),
 	}
 )
 
@@ -414,24 +414,24 @@ func (m *ManagerTestSuite) TestHealthCheckNodePort(c *C) {
 	clusterIP := *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("10.20.30.40"), 80, lb.ScopeExternal, 0)
 
 	// Create two node-local backends
-	localBackend1 := *lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.1"), 8080)
-	localBackend2 := *lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080)
-	localTerminatingBackend3 := *lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.3"), 8080)
+	localBackend1 := lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.1"), 8080)
+	localBackend2 := lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080)
+	localTerminatingBackend3 := lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.3"), 8080)
 	localBackend1.NodeName = nodeTypes.GetName()
 	localBackend2.NodeName = nodeTypes.GetName()
 	localTerminatingBackend3.NodeName = nodeTypes.GetName()
-	localActiveBackends := []lb.Backend{localBackend1, localBackend2}
+	localActiveBackends := []*lb.Backend{localBackend1, localBackend2}
 
 	// Create three remote backends
-	remoteBackend1 := *lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.3"), 8080)
-	remoteBackend2 := *lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.4"), 8080)
-	remoteBackend3 := *lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.5"), 8080)
+	remoteBackend1 := lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.3"), 8080)
+	remoteBackend2 := lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.4"), 8080)
+	remoteBackend3 := lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.5"), 8080)
 	remoteBackend1.NodeName = "not-" + nodeTypes.GetName()
 	remoteBackend2.NodeName = "not-" + nodeTypes.GetName()
 	remoteBackend3.NodeName = "not-" + nodeTypes.GetName()
-	remoteBackends := []lb.Backend{remoteBackend1, remoteBackend2, remoteBackend3}
+	remoteBackends := []*lb.Backend{remoteBackend1, remoteBackend2, remoteBackend3}
 
-	allBackends := []lb.Backend{localBackend1, localBackend2, localTerminatingBackend3, remoteBackend1, remoteBackend2, remoteBackend3}
+	allBackends := []*lb.Backend{localBackend1, localBackend2, localTerminatingBackend3, remoteBackend1, remoteBackend2, remoteBackend3}
 
 	// Insert svc1 as type LoadBalancer with some local backends
 	p1 := &lb.SVC{
@@ -570,9 +570,9 @@ func (m *ManagerTestSuite) TestHealthCheckNodePortDisabled(c *C) {
 
 func (m *ManagerTestSuite) TestGetServiceNameByAddr(c *C) {
 	fe := frontend1.DeepCopy()
-	be := make([]lb.Backend, 0, len(backends1))
+	be := make([]*lb.Backend, 0, len(backends1))
 	for _, backend := range backends1 {
-		be = append(be, *backend.DeepCopy())
+		be = append(be, backend.DeepCopy())
 	}
 	name := "svc1"
 	namespace := "ns1"
@@ -603,14 +603,14 @@ func (m *ManagerTestSuite) TestLocalRedirectLocalBackendSelection(c *C) {
 	// Create a node-local backend.
 	localBackend := backends1[0]
 	localBackend.NodeName = nodeTypes.GetName()
-	localBackends := []lb.Backend{localBackend}
+	localBackends := []*lb.Backend{localBackend}
 	// Create two remote backends.
-	remoteBackends := make([]lb.Backend, 0, len(backends2))
+	remoteBackends := make([]*lb.Backend, 0, len(backends2))
 	for _, backend := range backends2 {
 		backend.NodeName = "not-" + nodeTypes.GetName()
 		remoteBackends = append(remoteBackends, backend)
 	}
-	allBackends := make([]lb.Backend, 0, 1+len(remoteBackends))
+	allBackends := make([]*lb.Backend, 0, 1+len(remoteBackends))
 	allBackends = append(allBackends, localBackend)
 	allBackends = append(allBackends, remoteBackends...)
 
@@ -648,14 +648,14 @@ func (m *ManagerTestSuite) TestLocalRedirectServiceOverride(c *C) {
 	// Create a node-local backend.
 	localBackend := backends1[0]
 	localBackend.NodeName = nodeTypes.GetName()
-	localBackends := []lb.Backend{localBackend}
+	localBackends := []*lb.Backend{localBackend}
 	// Create two remote backends.
-	remoteBackends := make([]lb.Backend, 0, len(backends2))
+	remoteBackends := make([]*lb.Backend, 0, len(backends2))
 	for _, backend := range backends2 {
 		backend.NodeName = "not-" + nodeTypes.GetName()
 		remoteBackends = append(remoteBackends, backend)
 	}
-	allBackends := make([]lb.Backend, 0, 1+len(remoteBackends))
+	allBackends := make([]*lb.Backend, 0, 1+len(remoteBackends))
 	allBackends = append(allBackends, localBackend)
 	allBackends = append(allBackends, remoteBackends...)
 
@@ -759,7 +759,7 @@ func (m *ManagerTestSuite) TestUpsertServiceWithTerminatingBackends(c *C) {
 	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, len(backends1))
 
 	// Delete terminating backends.
-	p.Backends = []lb.Backend{}
+	p.Backends = []*lb.Backend{}
 
 	created, id1, err = m.svc.UpsertService(p)
 

--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -31,13 +31,13 @@ func NewLBMockMap() *LBMockMap {
 }
 
 func (m *LBMockMap) UpsertService(p *lbmap.UpsertServiceParams) error {
-	backendsList := make([]lb.Backend, 0, len(p.Backends))
+	backendsList := make([]*lb.Backend, 0, len(p.Backends))
 	for name, backendID := range p.Backends {
 		b, found := m.BackendByID[backendID]
 		if !found {
 			return fmt.Errorf("Backend %s (%d) not found", name, p.ID)
 		}
-		backendsList = append(backendsList, *b)
+		backendsList = append(backendsList, b)
 	}
 	if p.UseMaglev && len(p.Backends) != 0 {
 		if err := m.UpsertMaglevLookupTable(p.ID, p.Backends, p.IPv6); err != nil {


### PR DESCRIPTION
This change is a backport of https://github.com/cilium/cilium/pull/20410. We are looking into it to attempt solving some memory issues currently happening in some staging clusters. They are running over **k8s v1.22** and have some services leveraging **EndpointSlices**. #incident-18670 for more details.

#### Initial commit message

Change slices of Backends into slices of pointers to Backends. That way the slice can be garbage collected even if some parts of Backends are still in use.

Before this change the upsertService function had slice of backends. This slice was assgined to service (svc.backends) and then the notifyMonitorServiceUpsert function was used to push the even about the upsert. The event created contained some fields from the backends. Because of that the whole slice was kept in the memory.

After this fix the slice contains the pointers and they are not accessed later so the slice can be removed from the memory. Only the accessed fields need to be kept instead of whole objects.

Signed-off-by: Alan Kutniewski <kutniewski@google.com>
