### PR TITLE
Cherry-pick: In service recovery, don't skip if one of the service recovery fails

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -589,4 +589,16 @@ const (
 
 	// IPSec old SPI
 	OldSPI = "oldSPI"
+
+	// Number of Backends failed while restoration.
+	RestoredBackends = "restoredBackends"
+
+	// Number of Backends failed while restoration.
+	FailedBackends = "failedBackends"
+
+	// Number of Services failed while restoration.
+	RestoredSVCs = "restoredServices"
+
+	// Number of Services failed while restoration.
+	FailedSVCs = "failedServices"
 )


### PR DESCRIPTION
Cherry-picks https://github.com/cilium/cilium/commit/018856602b7637b8ae1c796f4ed02fe1bbeb5905 back to 1.11 to help avoid the issues we're seeing with agent restarts and https://github.com/cilium/cilium/issues/23551 