### PR TITLE
Check BPF map entry deletes really have done their job

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -880,7 +880,9 @@ func (s *Service) deleteOrphanBackends() error {
 
 			DeleteBackendID(b.ID)
 			if err := s.lbmap.DeleteBackendByID(b.ID, b.L3n4Addr.IsIPv6()); err != nil {
-				return fmt.Errorf("Unable to remove backend %d from map: %s", b.ID, err)
+				//return fmt.Errorf("Unable to remove backend %d from map: %s", b.ID, err)
+				log.Warningf("Unable to remove orphan backend %d from map (continuing): %s", b.ID, err)
+				continue
 			}
 			delete(s.backendByHash, hash)
 		}


### PR DESCRIPTION
* Check BPF map entry deletes really have done their job
* Make the resolver log it’s work at info level
* Avoid bailing on error in deleteOrphanBackends()

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
