### PR TITLE
cherry-pick: pkg/controller: introduce max retry interval for controllers

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
@@ -562,6 +563,7 @@ func (ipc *IPCache) TriggerLabelInjection(src source.Source, sc identityUpdater,
 				}
 				return nil
 			},
+			MaxRetryInterval: 1 * time.Minute,
 		},
 	)
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/cilium/cilium/commit/cda74a22f10ba8aa78e6899bbe8d613c69fe6265 back to v1.11
