### PR TITLE
[CMPT-1682] Backport https://github.com/cilium/cilium/pull/21387 to 1.11

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -57,8 +57,8 @@ cilium-operator-alibabacloud [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -63,8 +63,8 @@ cilium-operator-aws [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -60,8 +60,8 @@ cilium-operator-azure [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -56,8 +56,8 @@ cilium-operator-generic [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -69,8 +69,8 @@ cilium-operator [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -997,6 +997,14 @@
      - IPv6 CIDR list range to delegate to individual nodes for IPAM.
      - list
      - ``[]``
+   * - ipam.operator.externalAPILimitBurstSize
+     - The maximum burst size when rate limiting access to external APIs. Also known as the token bucket capacity.
+     - string
+     - ``20``
+   * - ipam.operator.externalAPILimitQPS
+     - The maximum queries per second when rate limiting access to external APIs. Also known as the bucket refill rate, which is used to refill the bucket up to the burst size capacity.
+     - string
+     - ``4.0``
    * - ipv4.enabled
      - Enable IPv4 support.
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -373,6 +373,8 @@ eventQueueSize
 extendable
 extensibility
 extern
+externalAPILimitBurstSize
+externalAPILimitQPS
 externalIPs
 externalWorkloads
 extraArgs

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -300,6 +300,8 @@ contributors across the globe, there is almost always someone available to help.
 | ipam.operator.clusterPoolIPv6MaskSize | int | `120` | IPv6 CIDR mask size to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv6PodCIDR | string | `"fd00::/104"` | Deprecated in favor of ipam.operator.clusterPoolIPv6PodCIDRList. IPv6 CIDR range to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv6PodCIDRList | list | `[]` | IPv6 CIDR list range to delegate to individual nodes for IPAM. |
+| ipam.operator.externalAPILimitBurstSize | string | `20` | The maximum burst size when rate limiting access to external APIs. Also known as the token bucket capacity. |
+| ipam.operator.externalAPILimitQPS | string | `4.0` | The maximum queries per second when rate limiting access to external APIs. Also known as the bucket refill rate, which is used to refill the bucket up to the burst size capacity. |
 | ipv4.enabled | bool | `true` | Enable IPv4 support. |
 | ipv6.enabled | bool | `false` | Enable IPv6 support. |
 | ipvlan.enabled | bool | `false` | Enable the IPVLAN datapath (deprecated) |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -755,6 +755,13 @@ data:
 {{- end }}
 {{- end }}
 
+{{- if .Values.ipam.operator.externalAPILimitBurstSize }}
+  limit-ipam-api-burst: {{ .Values.ipam.operator.externalAPILimitBurstSize | quote }}
+{{- end }}
+{{- if .Values.ipam.operator.externalAPILimitQPS }}
+  limit-ipam-api-qps: {{ .Values.ipam.operator.externalAPILimitQPS | quote }}
+{{- end }}
+
 {{- if .Values.enableCnpStatusUpdates }}
   disable-cnp-status-updates: {{ (not .Values.enableCnpStatusUpdates) | quote }}
 {{- else if (eq $defaultEnableCnpStatusUpdates "false") }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1026,6 +1026,15 @@ ipam:
     clusterPoolIPv6PodCIDRList: []
     # -- IPv6 CIDR mask size to delegate to individual nodes for IPAM.
     clusterPoolIPv6MaskSize: 120
+    # -- The maximum burst size when rate limiting access to external APIs.
+    # Also known as the token bucket capacity.
+    # @default -- `20`
+    externalAPILimitBurstSize: ~
+    # -- The maximum queries per second when rate limiting access to
+    # external APIs. Also known as the bucket refill rate, which is used to
+    # refill the bucket up to the burst size capacity.
+    # @default -- `4.0`
+    externalAPILimitQPS: ~
 
 # -- Configure the eBPF-based ip-masq-agent
 ipMasqAgent:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1021,6 +1021,15 @@ ipam:
     clusterPoolIPv6PodCIDRList: []
     # -- IPv6 CIDR mask size to delegate to individual nodes for IPAM.
     clusterPoolIPv6MaskSize: 120
+    # -- The maximum burst size when rate limiting access to external APIs.
+    # Also known as the token bucket capacity.
+    # @default -- `20`
+    externalAPILimitBurstSize: ~
+    # -- The maximum queries per second when rate limiting access to
+    # external APIs. Also known as the bucket refill rate, which is used to
+    # refill the bucket up to the burst size capacity.
+    # @default -- `4.0`
+    externalAPILimitQPS: ~
 
 # -- Configure the eBPF-based ip-masq-agent
 ipMasqAgent:

--- a/pkg/api/helpers/rate_limit_test.go
+++ b/pkg/api/helpers/rate_limit_test.go
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright Authors of Cilium
 
 //go:build !privileged_tests
-// +build !privileged_tests
 
 package helpers
 
@@ -11,9 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cilium/cilium/pkg/api/metrics/mock"
-
 	"gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/api/metrics/mock"
+	"github.com/cilium/cilium/pkg/checker"
 )
 
 func Test(t *testing.T) {
@@ -24,14 +24,48 @@ type HelpersSuite struct{}
 
 var _ = check.Suite(&HelpersSuite{})
 
-func (e *HelpersSuite) TestRateLimit(c *check.C) {
+func (e *HelpersSuite) TestRateLimitBurst(c *check.C) {
 	metricsAPI := mock.NewMockMetrics()
-	limiter := NewApiLimiter(metricsAPI, 10.0, 4)
+	limiter := NewApiLimiter(metricsAPI, 1, 10)
 	c.Assert(limiter, check.Not(check.IsNil))
 
+	// Exhaust bucket (rate limit should not kick in)
 	for i := 0; i < 10; i++ {
 		limiter.Limit(context.TODO(), "test")
 	}
+	c.Assert(metricsAPI.RateLimit("test"), check.Equals, time.Duration(0))
 
-	c.Assert(metricsAPI.RateLimit("test"), check.Not(check.DeepEquals), time.Duration(0))
+	// Rate limit should now kick in (use an expired context to avoid waiting 1sec)
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Microsecond)
+	defer cancel()
+	limiter.Limit(ctx, "test")
+	c.Assert(metricsAPI.RateLimit("test"), check.Not(checker.Equals), time.Duration(0))
+}
+
+func (e *HelpersSuite) TestRateLimitWait(c *check.C) {
+	metricsAPI := mock.NewMockMetrics()
+	limiter := NewApiLimiter(metricsAPI, 100, 1)
+	c.Assert(limiter, check.Not(check.IsNil))
+
+	// Exhaust bucket
+	limiter.Limit(context.TODO(), "test")
+	c.Assert(metricsAPI.RateLimit("test"), checker.Equals, time.Duration(0))
+
+	// Hit rate limit 15 times. The bucket refill rate is 100 per second,
+	// meaning we expect this to take around 15 * 10 = 150 milliseconds
+	start := time.Now()
+	for i := 0; i < 15; i++ {
+		limiter.Limit(context.TODO(), "test")
+	}
+	measured := time.Since(start)
+
+	// Measured duration should be approximately the accounted duration
+	accounted := metricsAPI.RateLimit("test")
+	if measured > 2*accounted {
+		// We allow the wait to be up to 2x larger than the expected wait time
+		// to avoid flaky tests. If you are reading this because this test has
+		// been flaky despite the 100% margin of error, my recommendation
+		// is to disable this check by replacing the c.Errorf below with c.Logf
+		c.Errorf("waited longer than expected (expected %s (+/-100%%), measured %s)", accounted, measured)
+	}
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -372,10 +372,10 @@ const (
 	ParallelAllocWorkers = 50
 
 	// IPAMAPIBurst is the default burst value when rate limiting access to external APIs
-	IPAMAPIBurst = 4
+	IPAMAPIBurst = 20
 
 	// IPAMAPIQPSLimit is the default QPS limit when rate limiting access to external APIs
-	IPAMAPIQPSLimit = 20.0
+	IPAMAPIQPSLimit = 4.0
 
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node


### PR DESCRIPTION
All commits from https://github.com/cilium/cilium/pull/21387 are backported here.

There were a couple of small conflicts:
- `pkg/api/helpers/rate_limit_test.go` (I took the version from aefa29195686b2e985bc879a24389c3f8cd40850)
- `Documentation/operations/upgrade.rst` (I took the version from our `v1.11-dd` branch)

The unit test which was updated succeeds locally:
```
cilium/pkg/api/helpers $ go test
OK: 3 passed
PASS
ok  	github.com/cilium/cilium/pkg/api/helpers	0.477s
```