### PR TITLE
[CMPT-1682] Backport https://github.com/cilium/cilium/pull/26277 to 1.11

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -377,7 +377,10 @@ func generateIpConfigName() string {
 func (c *Client) AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, vmssName, subnetID, interfaceName string, addresses int) error {
 	var netIfConfig *compute.VirtualMachineScaleSetNetworkConfiguration
 
+	c.limiter.Limit(ctx, "VirtualMachineScaleSetVMs.Get")
+	sinceStart := spanstat.Start()
 	result, err := c.vmss.Get(ctx, c.resourceGroup, vmssName, instanceID, compute.InstanceViewTypesInstanceView)
+	c.metricsAPI.ObserveAPICall("VirtualMachineScaleSetVMs.Get", deriveStatus(err), sinceStart.Seconds())
 	if err != nil {
 		return fmt.Errorf("failed to get VM %s from VMSS %s: %s", instanceID, vmssName, err)
 	}
@@ -431,21 +434,27 @@ func (c *Client) AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, v
 		result.StorageProfile.ImageReference = nil
 	}
 
+	c.limiter.Limit(ctx, "VirtualMachineScaleSetVMs.Update")
+	sinceStart = spanstat.Start()
 	future, err := c.vmss.Update(ctx, c.resourceGroup, vmssName, instanceID, result)
+	defer c.metricsAPI.ObserveAPICall("VirtualMachineScaleSetVMs.Update", deriveStatus(err), sinceStart.Seconds())
 	if err != nil {
 		return fmt.Errorf("unable to update virtualmachinescaleset: %s", err)
 	}
 
-	if err := future.WaitForCompletionRef(ctx, c.vmss.Client); err != nil {
+	err = future.WaitForCompletionRef(ctx, c.vmss.Client)
+	if err != nil {
 		return fmt.Errorf("error while waiting for virtualmachinescalesets.Update() to complete: %s", err)
 	}
-
 	return nil
 }
 
 // AssignPrivateIpAddressesVM assign a private IP to an interface attached to a standalone instance
 func (c *Client) AssignPrivateIpAddressesVM(ctx context.Context, subnetID, interfaceName string, addresses int) error {
+	c.limiter.Limit(ctx, "Interfaces.Get")
+	sinceStart := spanstat.Start()
 	iface, err := c.interfaces.Get(ctx, c.resourceGroup, interfaceName, "")
+	c.metricsAPI.ObserveAPICall("Interfaces.Get", deriveStatus(err), sinceStart.Seconds())
 	if err != nil {
 		return fmt.Errorf("failed to get standalone instance's interface %s: %s", interfaceName, err)
 	}
@@ -475,12 +484,16 @@ func (c *Client) AssignPrivateIpAddressesVM(ctx context.Context, subnetID, inter
 	ipConfigurations = append(*iface.IPConfigurations, ipConfigurations...)
 	iface.IPConfigurations = &ipConfigurations
 
+	c.limiter.Limit(ctx, "Interfaces.CreateOrUpdate")
+	sinceStart = spanstat.Start()
 	future, err := c.interfaces.CreateOrUpdate(ctx, c.resourceGroup, interfaceName, iface)
+	defer c.metricsAPI.ObserveAPICall("Interfaces.CreateOrUpdate", deriveStatus(err), sinceStart.Seconds())
 	if err != nil {
 		return fmt.Errorf("unable to update interface %s: %s", interfaceName, err)
 	}
 
-	if err := future.WaitForCompletionRef(ctx, c.interfaces.Client); err != nil {
+	err = future.WaitForCompletionRef(ctx, c.interfaces.Client)
+	if err != nil {
 		return fmt.Errorf("error while waiting for interface.CreateOrUpdate() to complete for %s: %s", interfaceName, err)
 	}
 


### PR DESCRIPTION
See https://github.com/cilium/cilium/pull/26277 for more details.

There was a small conflict because of https://github.com/cilium/cilium/pull/22534 which we don't have in our 1.11 branch (`ApiLimiter` was renamed to `APILimiter`). I chose not to backport this PR and kept `ApiLimiter` in our code for now.