### PR TITLE
v1.12 Cherry-picks

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -59,8 +59,8 @@ cilium-operator-alibabacloud [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -65,8 +65,8 @@ cilium-operator-aws [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -62,8 +62,8 @@ cilium-operator-azure [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -58,8 +58,8 @@ cilium-operator-generic [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -70,8 +70,8 @@ cilium-operator [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1249,6 +1249,14 @@
      - IPv6 CIDR list range to delegate to individual nodes for IPAM.
      - list
      - ``[]``
+   * - ipam.operator.externalAPILimitBurstSize
+     - The maximum burst size when rate limiting access to external APIs. Also known as the token bucket capacity.
+     - string
+     - ``20``
+   * - ipam.operator.externalAPILimitQPS
+     - The maximum queries per second when rate limiting access to external APIs. Also known as the bucket refill rate, which is used to refill the bucket up to the burst size capacity.
+     - string
+     - ``4.0``
    * - ipv4.enabled
      - Enable IPv4 support.
      - bool

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -378,6 +378,13 @@ Annotations:
   flushing the current state by running the following command on each node:
   ``ip xfrm state flush && ip xfrm policy flush``.  
 
+* The ``limit-ipam-api-burst`` and ``limit-ipam-api-qps`` default values have
+  been made more conservative to better reflect the rate limits used by cloud
+  providers. The new default values are ``limit-ipam-api-burst=20`` and
+  ``limit-ipam-api-qps=4``.
+  Use the Helm values ``ipam.operator.externalAPILimit{BurstSize,QPS}`` to
+  reconfigure if needed.
+
 New Options
 ~~~~~~~~~~~
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -400,6 +400,8 @@ eventQueueSize
 extendable
 extensibility
 extern
+externalAPILimitBurstSize
+externalAPILimitQPS
 externalIPs
 externalWorkloads
 extraArgs

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -363,6 +363,8 @@ contributors across the globe, there is almost always someone available to help.
 | ipam.operator.clusterPoolIPv6MaskSize | int | `120` | IPv6 CIDR mask size to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv6PodCIDR | string | `"fd00::/104"` | Deprecated in favor of ipam.operator.clusterPoolIPv6PodCIDRList. IPv6 CIDR range to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv6PodCIDRList | list | `[]` | IPv6 CIDR list range to delegate to individual nodes for IPAM. |
+| ipam.operator.externalAPILimitBurstSize | string | `20` | The maximum burst size when rate limiting access to external APIs. Also known as the token bucket capacity. |
+| ipam.operator.externalAPILimitQPS | string | `4.0` | The maximum queries per second when rate limiting access to external APIs. Also known as the bucket refill rate, which is used to refill the bucket up to the burst size capacity. |
 | ipv4.enabled | bool | `true` | Enable IPv4 support. |
 | ipv6.enabled | bool | `false` | Enable IPv6 support. |
 | k8s | object | `{}` | Configure Kubernetes specific configuration |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -805,6 +805,13 @@ data:
 {{- end }}
 {{- end }}
 
+{{- if .Values.ipam.operator.externalAPILimitBurstSize }}
+  limit-ipam-api-burst: {{ .Values.ipam.operator.externalAPILimitBurstSize | quote }}
+{{- end }}
+{{- if .Values.ipam.operator.externalAPILimitQPS }}
+  limit-ipam-api-qps: {{ .Values.ipam.operator.externalAPILimitQPS | quote }}
+{{- end }}
+
 {{- if .Values.enableCnpStatusUpdates }}
   disable-cnp-status-updates: {{ (not .Values.enableCnpStatusUpdates) | quote }}
 {{- else if (eq $defaultEnableCnpStatusUpdates "false") }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1204,6 +1204,15 @@ ipam:
     clusterPoolIPv6PodCIDRList: []
     # -- IPv6 CIDR mask size to delegate to individual nodes for IPAM.
     clusterPoolIPv6MaskSize: 120
+    # -- The maximum burst size when rate limiting access to external APIs.
+    # Also known as the token bucket capacity.
+    # @default -- `20`
+    externalAPILimitBurstSize: ~
+    # -- The maximum queries per second when rate limiting access to
+    # external APIs. Also known as the bucket refill rate, which is used to
+    # refill the bucket up to the burst size capacity.
+    # @default -- `4.0`
+    externalAPILimitQPS: ~
 
 # -- Configure the eBPF-based ip-masq-agent
 ipMasqAgent:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1201,6 +1201,15 @@ ipam:
     clusterPoolIPv6PodCIDRList: []
     # -- IPv6 CIDR mask size to delegate to individual nodes for IPAM.
     clusterPoolIPv6MaskSize: 120
+    # -- The maximum burst size when rate limiting access to external APIs.
+    # Also known as the token bucket capacity.
+    # @default -- `20`
+    externalAPILimitBurstSize: ~
+    # -- The maximum queries per second when rate limiting access to
+    # external APIs. Also known as the bucket refill rate, which is used to
+    # refill the bucket up to the burst size capacity.
+    # @default -- `4.0`
+    externalAPILimitQPS: ~
 
 # -- Configure the eBPF-based ip-masq-agent
 ipMasqAgent:

--- a/pkg/api/helpers/rate_limit_test.go
+++ b/pkg/api/helpers/rate_limit_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/api/metrics/mock"
+	"github.com/cilium/cilium/pkg/checker"
 )
 
 func Test(t *testing.T) {
@@ -23,14 +24,48 @@ type HelpersSuite struct{}
 
 var _ = check.Suite(&HelpersSuite{})
 
-func (e *HelpersSuite) TestRateLimit(c *check.C) {
+func (e *HelpersSuite) TestRateLimitBurst(c *check.C) {
 	metricsAPI := mock.NewMockMetrics()
-	limiter := NewApiLimiter(metricsAPI, 10.0, 4)
+	limiter := NewApiLimiter(metricsAPI, 1, 10)
 	c.Assert(limiter, check.Not(check.IsNil))
 
+	// Exhaust bucket (rate limit should not kick in)
 	for i := 0; i < 10; i++ {
 		limiter.Limit(context.TODO(), "test")
 	}
+	c.Assert(metricsAPI.RateLimit("test"), check.Equals, time.Duration(0))
 
-	c.Assert(metricsAPI.RateLimit("test"), check.Not(check.DeepEquals), time.Duration(0))
+	// Rate limit should now kick in (use an expired context to avoid waiting 1sec)
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Microsecond)
+	defer cancel()
+	limiter.Limit(ctx, "test")
+	c.Assert(metricsAPI.RateLimit("test"), check.Not(checker.Equals), time.Duration(0))
+}
+
+func (e *HelpersSuite) TestRateLimitWait(c *check.C) {
+	metricsAPI := mock.NewMockMetrics()
+	limiter := NewApiLimiter(metricsAPI, 100, 1)
+	c.Assert(limiter, check.Not(check.IsNil))
+
+	// Exhaust bucket
+	limiter.Limit(context.TODO(), "test")
+	c.Assert(metricsAPI.RateLimit("test"), checker.Equals, time.Duration(0))
+
+	// Hit rate limit 15 times. The bucket refill rate is 100 per second,
+	// meaning we expect this to take around 15 * 10 = 150 milliseconds
+	start := time.Now()
+	for i := 0; i < 15; i++ {
+		limiter.Limit(context.TODO(), "test")
+	}
+	measured := time.Since(start)
+
+	// Measured duration should be approximately the accounted duration
+	accounted := metricsAPI.RateLimit("test")
+	if measured > 2*accounted {
+		// We allow the wait to be up to 2x larger than the expected wait time
+		// to avoid flaky tests. If you are reading this because this test has
+		// been flaky despite the 100% margin of error, my recommendation
+		// is to disable this check by replacing the c.Errorf below with c.Logf
+		c.Errorf("waited longer than expected (expected %s (+/-100%%), measured %s)", accounted, measured)
+	}
 }

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -27,6 +27,7 @@ import (
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/math"
 )
 
@@ -229,6 +230,9 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (a *ipam.AllocationA
 		}
 		if n.node.Ops().IsPrefixDelegated() {
 			effectiveLimits = effectiveLimits * option.ENIPDBlockSizeIPv4
+		} else if len(e.Prefixes) > 0 {
+			// If prefix delegation was previously enabled on this node, account for IPs from prefixes
+			effectiveLimits += len(e.Prefixes) * (option.ENIPDBlockSizeIPv4 - 1)
 		}
 
 		availableOnENI := math.IntMax(effectiveLimits-len(e.Addresses), 0)
@@ -261,6 +265,21 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (a *ipam.AllocationA
 	return
 }
 
+// isSubnetAtCapacity parses error from AWS SDK to understand if the subnet is out of capacity either due to out of
+// prefixes or IPs
+func isSubnetAtCapacity(err error) bool {
+	var apiErr smithy.APIError
+	errorStr := "There aren't sufficient free Ipv4 addresses or prefixes"
+	if errors.As(err, &apiErr) {
+		// Unfortunately SDK v1 has better error handling than v2. AWS VPC CNI plugin still uses v1 and relies on error
+		// codes like PrivateIpAddressLimitExceeded.
+		// See https://github.com/aws/amazon-vpc-cni-k8s/blob/fd8bcf0be4b522d13fb69c18539921452e4dec80/pkg/awsutils/awsutils.go#L1477-L1487 for more details.
+		// Cilium uses v2 SDK, so we need to rely on string comparison until the SDK supports custom errors.
+		return apiErr.ErrorCode() == "InvalidParameterValue" && strings.Contains(apiErr.ErrorMessage(), errorStr)
+	}
+	return false
+}
+
 // AllocateIPs performs the ENI allocation oepration
 func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error {
 	// Check if the interface to allocate on is prefix delegated
@@ -270,7 +289,15 @@ func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error 
 
 	if isPrefixDelegated {
 		numPrefixes := ip.PrefixCeil(a.AvailableForAllocation, option.ENIPDBlockSizeIPv4)
-		return n.manager.api.AssignENIPrefixes(ctx, a.InterfaceID, int32(numPrefixes))
+		err := n.manager.api.AssignENIPrefixes(ctx, a.InterfaceID, int32(numPrefixes))
+		if !isSubnetAtCapacity(err) {
+			return err
+		}
+		// Subnet might be out of available /28 prefixes, but /32 IP addresses might be available.
+		// We should attempt to allocate /32 IPs.
+		n.loggerLocked().WithFields(logrus.Fields{
+			logfields.Node: n.k8sObj.Name,
+		}).Warning("Subnet might be out of prefixes, operator will not allocate prefixes on this node anymore")
 	}
 	return n.manager.api.AssignPrivateIpAddresses(ctx, a.InterfaceID, int32(a.AvailableForAllocation))
 }
@@ -438,7 +465,15 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 
 	eniID, eni, err := n.manager.api.CreateNetworkInterface(ctx, int32(toAllocate), bestSubnet.ID, desc, securityGroupIDs, isPrefixDelegated)
 	if err != nil {
-		return 0, errUnableToCreateENI, fmt.Errorf("%s %s", errUnableToCreateENI, err)
+		if isPrefixDelegated && isSubnetAtCapacity(err) {
+			// Subnet might be out of available /28 prefixes, but /32 IP addresses might be available.
+			// We should attempt to allocate /32 IPs.
+			scopedLog.WithField(logfields.Node, n.k8sObj.Name).Warning("Subnet might be out of prefixes, operator will not allocate prefixes on this node anymore")
+			eniID, eni, err = n.manager.api.CreateNetworkInterface(ctx, int32(toAllocate), bestSubnet.ID, desc, securityGroupIDs, false)
+		}
+		if err != nil {
+			return 0, errUnableToCreateENI, fmt.Errorf("%s %s", errUnableToCreateENI, err)
+		}
 	}
 
 	scopedLog = scopedLog.WithField(fieldEniID, eniID)

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -382,6 +382,7 @@ func generateIpConfigName() string {
 func (c *Client) AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, vmssName, subnetID, interfaceName string, addresses int) error {
 	var netIfConfig *compute.VirtualMachineScaleSetNetworkConfiguration
 
+	c.limiter.Limit(ctx, "VirtualMachineScaleSetVMs.Get")
 	result, err := c.vmss.Get(ctx, c.resourceGroup, vmssName, instanceID, compute.InstanceViewTypesInstanceView)
 	if err != nil {
 		return fmt.Errorf("failed to get VM %s from VMSS %s: %s", instanceID, vmssName, err)
@@ -436,6 +437,7 @@ func (c *Client) AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, v
 		result.StorageProfile.ImageReference = nil
 	}
 
+	c.limiter.Limit(ctx, "VirtualMachineScaleSetVMs.Update")
 	future, err := c.vmss.Update(ctx, c.resourceGroup, vmssName, instanceID, result)
 	if err != nil {
 		return fmt.Errorf("unable to update virtualmachinescaleset: %s", err)
@@ -450,6 +452,7 @@ func (c *Client) AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, v
 
 // AssignPrivateIpAddressesVM assign a private IP to an interface attached to a standalone instance
 func (c *Client) AssignPrivateIpAddressesVM(ctx context.Context, subnetID, interfaceName string, addresses int) error {
+	c.limiter.Limit(ctx, "Interfaces.Get")
 	iface, err := c.interfaces.Get(ctx, c.resourceGroup, interfaceName, "")
 	if err != nil {
 		return fmt.Errorf("failed to get standalone instance's interface %s: %s", interfaceName, err)
@@ -480,6 +483,7 @@ func (c *Client) AssignPrivateIpAddressesVM(ctx context.Context, subnetID, inter
 	ipConfigurations = append(*iface.IPConfigurations, ipConfigurations...)
 	iface.IPConfigurations = &ipConfigurations
 
+	c.limiter.Limit(ctx, "Interfaces.CreateOrUpdate")
 	future, err := c.interfaces.CreateOrUpdate(ctx, c.resourceGroup, interfaceName, iface)
 	if err != nil {
 		return fmt.Errorf("unable to update interface %s: %s", interfaceName, err)

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1612,6 +1612,7 @@ func (m *IptablesManager) addCiliumENIRules() error {
 
 	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
 	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
+	identityMarkMask := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIdentity, linux_defaults.MagicMarkHostMask)
 
 	// Note: these rules need the xt_connmark module (iptables usually
 	// loads it when required, unless loading modules after boot has been
@@ -1631,5 +1632,12 @@ func (m *IptablesManager) addCiliumENIRules() error {
 		"-A", ciliumPreMangleChain,
 		"-i", "lxc+",
 		"-m", "comment", "--comment", "cilium: primary ENI",
+		// Don't restore the mark when we are carrying the identity with mark,
+		// because we are using 7th bit to carry the uppermost bit of the identity
+		// and it is overlapping with ENI's mark. Below --restore-mark "restores"
+		// the connmark and it zeros the 7th bit when connmark is zero. As a result,
+		// identity will be changed. This will become a problem only when we are
+		// setting the ClusterID 128-255.
+		"-m", "mark", "!", "--mark", identityMarkMask,
 		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask})
 }

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -378,6 +378,10 @@ func lookupRule(spec Rule, family int) (bool, error) {
 			continue
 		}
 
+		if spec.Mask != 0 && r.Mask != spec.Mask {
+			continue
+		}
+
 		if r.Table == spec.Table {
 			return true, nil
 		}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -149,8 +149,10 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing types.NodeAddressi
 	if err := route.ReplaceRule(route.Rule{
 		Priority: linux_defaults.RulePriorityNodeport,
 		Mark:     linux_defaults.MarkMultinodeNodeport,
-		Mask:     linux_defaults.MaskMultinodeNodeport,
-		Table:    route.MainTable,
+		// Avoid selecting this rule when we're carrying identity with mark. See corresponding primary ENI iptables rule
+		// to restore connmark for more details
+		Mask:  linux_defaults.MagicMarkIdentity | linux_defaults.MaskMultinodeNodeport,
+		Table: route.MainTable,
 	}); err != nil {
 		return nil, fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -146,6 +146,19 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing types.NodeAddressi
 		Val:       "2",
 		IgnoreErr: false,
 	})
+	// Delete old nodeport rule if it exists
+	oldRule := route.Rule{
+		Priority: linux_defaults.RulePriorityNodeport,
+		Mark:     linux_defaults.MarkMultinodeNodeport,
+		Mask:     linux_defaults.MaskMultinodeNodeport,
+		Table:    route.MainTable,
+	}
+	if err := route.DeleteRule(oldRule); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("unable to delete old ip rule for ENI multi-node NodePort: %w", err)
+		}
+	}
+	// Install updated ip rule for ENI multi-node NodePort
 	if err := route.ReplaceRule(route.Rule{
 		Priority: linux_defaults.RulePriorityNodeport,
 		Mark:     linux_defaults.MarkMultinodeNodeport,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -385,10 +385,10 @@ const (
 	ParallelAllocWorkers = 50
 
 	// IPAMAPIBurst is the default burst value when rate limiting access to external APIs
-	IPAMAPIBurst = 4
+	IPAMAPIBurst = 20
 
 	// IPAMAPIQPSLimit is the default QPS limit when rate limiting access to external APIs
-	IPAMAPIQPSLimit = 20.0
+	IPAMAPIQPSLimit = 4.0
 
 	// IPAMPodCIDRAllocationThreshold is the default value for
 	// CiliumNode.Spec.IPAM.PodCIDRAllocationThreshold if no value is set

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -182,12 +182,16 @@ func NewTriggerMetrics(namespace, name string) *triggerMetrics {
 			Subsystem: ipamSubsystem,
 			Name:      name + "_duration_seconds",
 			Help:      "Duration of trigger runs",
+			Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
+				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
 		}),
 		latency: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: ipamSubsystem,
 			Name:      name + "_latency_seconds",
 			Help:      "Latency between queue and trigger run",
+			Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
+				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
 		}),
 	}
 }

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -579,6 +580,7 @@ func (ipc *IPCache) TriggerLabelInjection(src source.Source) {
 				}
 				return nil
 			},
+			MaxRetryInterval: 1 * time.Minute,
 		},
 	)
 }


### PR DESCRIPTION
Cherry-pick the following upstream commits into 1.12:
* https://github.com/DataDog/cilium/pull/286 
  * No conflicts
  * I tried to cherry-pick https://github.com/cilium/cilium/pull/20822 instead but, it relies on other 1.13 changes. Instead I've forward ported(?) the 1.10 change above. 
* https://github.com/cilium/cilium/pull/23049
  * No conflicts
* https://github.com/cilium/cilium/pull/21886
  *  No conflicts
* https://github.com/cilium/cilium/pull/21387
  * Minor conflict in `Documentation/operations/upgrade.rst`
* https://github.com/cilium/cilium/pull/25600
  * No conflicts
* https://github.com/cilium/cilium/pull/26277
  * No conflicts