### PR TITLE
[aws][eni] Ensure security-groups are sorted

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -322,6 +322,7 @@ func (n *Node) getSecurityGroupIDs(ctx context.Context, eniSpec eniTypes.ENISpec
 			for _, secGroup := range securityGroups {
 				groups = append(groups, secGroup.ID)
 			}
+			sort.Strings(groups)
 			return groups, nil
 		}
 	}
@@ -341,6 +342,8 @@ func (n *Node) getSecurityGroupIDs(ctx context.Context, eniSpec eniTypes.ENISpec
 	if securityGroups == nil {
 		return nil, fmt.Errorf("failed to get security group ids")
 	}
+
+	sort.Strings(securityGroups)
 
 	return securityGroups, nil
 }


### PR DESCRIPTION
Cherry-picking https://github.com/cilium/cilium/pull/26508 back to 1.11 