### PR TITLE
Setup Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,9 +33,7 @@ build-docker-image-operator:
     IMAGE_NAME: cilium-operator
     DOCKERFILE_PATH: images/operator/Dockerfile
     DOCKER_BUILD_ARGS: |
-      BASE_IMAGE=registry.ddbuild.io/images/base/gbi-distroless:latest@sha256:be05d4c795fa14da8c21ef40f0f4dd257095adf204a44e2b24676a92c03ea52d
-      GOLANG_IMAGE=docker.io/library/golang:1.18.10@sha256:50c889275d26f816b5314fc99f55425fa76b18fcaf16af255f5d57f09e1f48da
-      ALPINE_IMAGE=docker.io/library/alpine:3.16.6@sha256:cbe5d5973103a2d03408d1689a6efde4ea4920bde9f4b51fe7872e60ce2d8e56
+      BASE_IMAGE=registry.ddbuild.io/images/base/gbi-distroless:release@sha256:be05d4c795fa14da8c21ef40f0f4dd257095adf204a44e2b24676a92c03ea52d
       OPERATOR_VARIANT=operator
 
 build-docker-image-runtime:
@@ -44,7 +42,7 @@ build-docker-image-runtime:
     IMAGE_NAME: cilium-runtime
     DOCKERFILE_PATH: images/runtime/Dockerfile
     DOCKER_BUILD_ARGS: |
-      UBUNTU_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2004:latest@sha256:cdd429fbdb99e2e2ab68be54731b4d7f97206077e22dec24c561a4aba907de91
+      UBUNTU_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2004:release@sha256:cdd429fbdb99e2e2ab68be54731b4d7f97206077e22dec24c561a4aba907de91
     DOCKER_CONTEXT: "./images/runtime"
     TARGET: build
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  CI_DOCKER_IMAGE: registry.ddbuild.io/images/docker@sha256:23643e6da71fc2551046a1928c071e6db5770f050a0f5a1e613168d2c65fb8bc # Docker 20.10.13
+  CI_DOCKER_IMAGE: registry.ddbuild.io/images/docker:24.0.4-gbi-focal
   DOCKER_CONTEXT: "."
   DOCKER_BUILD_ARGS: ""
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,61 @@
+variables:
+  CI_DOCKER_IMAGE: registry.ddbuild.io/images/docker@sha256:23643e6da71fc2551046a1928c071e6db5770f050a0f5a1e613168d2c65fb8bc # Docker 20.10.13
+  DOCKER_CONTEXT: "."
+  DOCKER_BUILD_ARGS: ""
+
+.build-docker-image: &build-docker-image
+  stage: build
+  image: $CI_DOCKER_IMAGE
+  tags: ["runner:docker"]
+  rules:
+    # For all branches ending with -dd, automatically push to prod
+    - if: $CI_COMMIT_BRANCH =~ /.*-dd/
+      variables:
+        TARGET: prod
+    # Otherwise, create manual jobs for pushing to staging
+    - if: $CI_COMMIT_BRANCH
+      variables:
+        TARGET: staging
+      when: manual
+  script:
+    - set -x
+    - builder=$(docker buildx create --use)
+    - trap "docker buildx rm $builder" EXIT
+    # Ex: v18411704-d9bda6da-1.12.11
+    - IMAGE_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-$(cat VERSION)"
+    # Construct valid --build-args arguments from the DOCKER_BUILD_ARGS variable
+    - BUILD_ARGS=""; IFS=$'\n'; for arg in $DOCKER_BUILD_ARGS; do BUILD_ARGS+=" $(echo "--build-arg $arg")"; done; IFS=$' ';
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label TARGET=$TARGET --push $DOCKER_CONTEXT
+
+build-docker-image-operator:
+  <<: *build-docker-image
+  variables:
+    IMAGE_NAME: cilium-operator
+    DOCKERFILE_PATH: images/operator/Dockerfile
+    DOCKER_BUILD_ARGS: |
+      BASE_IMAGE=registry.ddbuild.io/images/base/gbi-distroless:latest@sha256:be05d4c795fa14da8c21ef40f0f4dd257095adf204a44e2b24676a92c03ea52d
+      GOLANG_IMAGE=docker.io/library/golang:1.18.10@sha256:50c889275d26f816b5314fc99f55425fa76b18fcaf16af255f5d57f09e1f48da
+      ALPINE_IMAGE=docker.io/library/alpine:3.16.6@sha256:cbe5d5973103a2d03408d1689a6efde4ea4920bde9f4b51fe7872e60ce2d8e56
+      OPERATOR_VARIANT=operator
+
+build-docker-image-runtime:
+  <<: *build-docker-image
+  variables:
+    IMAGE_NAME: cilium-runtime
+    DOCKERFILE_PATH: images/runtime/Dockerfile
+    DOCKER_BUILD_ARGS: |
+      UBUNTU_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2004:latest@sha256:cdd429fbdb99e2e2ab68be54731b4d7f97206077e22dec24c561a4aba907de91
+    DOCKER_CONTEXT: "./images/runtime"
+    TARGET: build
+
+build-docker-image-cilium:
+  <<: *build-docker-image
+  needs:
+    # The cilium image depends on the runtime image
+    - build-docker-image-runtime
+  variables:
+    IMAGE_NAME: cilium
+    DOCKERFILE_PATH: images/cilium/Dockerfile
+  before_script:
+    # Reconstruct the cilium-runtime image version built in the build-docker-image-runtime job
+    - DOCKER_BUILD_ARGS+="CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-$(cat VERSION)"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ build-docker-image-operator:
     IMAGE_NAME: cilium-operator
     DOCKERFILE_PATH: images/operator/Dockerfile
     DOCKER_BUILD_ARGS: |
-      BASE_IMAGE=registry.ddbuild.io/images/base/gbi-distroless:release@sha256:be05d4c795fa14da8c21ef40f0f4dd257095adf204a44e2b24676a92c03ea52d
+      BASE_IMAGE=registry.ddbuild.io/images/base/gbi-distroless:release
       OPERATOR_VARIANT=operator
 
 build-docker-image-runtime:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ build-docker-image-runtime:
     IMAGE_NAME: cilium-runtime
     DOCKERFILE_PATH: images/runtime/Dockerfile
     DOCKER_BUILD_ARGS: |
-      UBUNTU_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2004:release@sha256:cdd429fbdb99e2e2ab68be54731b4d7f97206077e22dec24c561a4aba907de91
+      UBUNTU_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2004:release
     DOCKER_CONTEXT: "./images/runtime"
     TARGET: build
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,24 +8,16 @@ variables:
   image: $CI_DOCKER_IMAGE
   tags: ["runner:docker"]
   rules:
-    # For all branches ending with -dd, automatically push to prod
-    - if: $CI_COMMIT_BRANCH =~ /.*-dd/
-      variables:
-        TARGET: prod
-    # Otherwise, create manual jobs for pushing to staging
-    - if: $CI_COMMIT_BRANCH
-      variables:
-        TARGET: staging
-      when: manual
+    # Automatically run the pipeline for all pushed tags
+    - if: $CI_COMMIT_TAG
   script:
     - set -x
     - builder=$(docker buildx create --use)
     - trap "docker buildx rm $builder" EXIT
-    # Ex: v18411704-d9bda6da-1.12.11
-    - IMAGE_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-$(cat VERSION)"
     # Construct valid --build-args arguments from the DOCKER_BUILD_ARGS variable
     - BUILD_ARGS=""; IFS=$'\n'; for arg in $DOCKER_BUILD_ARGS; do BUILD_ARGS+=" $(echo "--build-arg $arg")"; done; IFS=$' ';
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=$TARGET --push $DOCKER_CONTEXT
+    - IMAGE_TAG="registry.ddbuild.io/$IMAGE_NAME:$CI_COMMIT_TAG"
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_TAG --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --push $DOCKER_CONTEXT
 
 build-docker-image-operator:
   <<: *build-docker-image
@@ -54,6 +46,5 @@ build-docker-image-cilium:
   variables:
     IMAGE_NAME: cilium
     DOCKERFILE_PATH: images/cilium/Dockerfile
-  before_script:
-    # Reconstruct the cilium-runtime image version built in the build-docker-image-runtime job
-    - DOCKER_BUILD_ARGS+="CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-$(cat VERSION)"
+    DOCKER_BUILD_ARGS: |
+      CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ variables:
     - IMAGE_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-$(cat VERSION)"
     # Construct valid --build-args arguments from the DOCKER_BUILD_ARGS variable
     - BUILD_ARGS=""; IFS=$'\n'; for arg in $DOCKER_BUILD_ARGS; do BUILD_ARGS+=" $(echo "--build-arg $arg")"; done; IFS=$' ';
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label TARGET=$TARGET --push $DOCKER_CONTEXT
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=$TARGET --push $DOCKER_CONTEXT
 
 build-docker-image-operator:
   <<: *build-docker-image

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -58,6 +58,10 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
     ./build-gops.sh
 
 FROM ${BASE_IMAGE}
+
+# Datadog Modification: operator has to run as root
+USER root
+
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.

--- a/images/runtime/Dockerfile
+++ b/images/runtime/Dockerfile
@@ -31,6 +31,9 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium/images/r
 
 FROM ${UBUNTU_IMAGE} as rootfs
 
+# Datadog modification: to be able to run APT we need to be root, Cilium also need to run as root
+USER root
+
 # Change the number to force the generation of a new git-tree SHA. Useful when
 # we want to re-run 'apt-get upgrade' for stale images.
 ENV FORCE_BUILD=6
@@ -68,6 +71,5 @@ RUN /test/bin/cst -C /test/llvm
 RUN /test/bin/cst -C /test/bpftool
 RUN /test/bin/cst -C /test/iproute2
 
-FROM scratch
-LABEL maintainer="maintainer@cilium.io"
-COPY --from=rootfs / /
+# Datadog modification: do not squash the layers to not lose GBI labels
+FROM rootfs


### PR DESCRIPTION
Very simple Gitlab CI setup for building Docker images. This builds 3 images for now:
- `cilium-operator` ([example successful job](https://gitlab.ddbuild.io/DataDog/cilium/-/jobs/305650727))
- `cilium-runtime` ([example successful job](https://gitlab.ddbuild.io/DataDog/cilium/-/jobs/305650728))
- `cilium` which depends on `cilium-runtime` ([example successful job](https://gitlab.ddbuild.io/DataDog/cilium/-/jobs/305650729))

The only changes to upstream images I needed to do were GBI-related: in the `cilium-runtime` image we need root + need to keep the base image labels; we also need root in the `cilium-operator` image.

