### PR TITLE
Cherry-pick: Retain CiliumInternalIP from CiliumNode when local data is unavailable

### DIFF
--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -138,6 +138,7 @@ func ParseNode(k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node 
 
 	k8sNodeAddHostIP(annotation.CiliumHostIP)
 	k8sNodeAddHostIP(annotation.CiliumHostIPv6)
+	newNode.IPAddresses = addrs
 
 	if key, ok := k8sNode.Annotations[annotation.CiliumEncryptionKey]; ok {
 		if u, err := strconv.ParseUint(key, 10, 8); err == nil {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -461,6 +461,7 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 	localCN := n.localNode.ToCiliumNode()
 	nodeResource.ObjectMeta.Annotations = localCN.Annotations
 
+	var oldCiliumNodeInternalIPs []string
 	for _, k8sAddress := range k8sNodeAddresses {
 		// Do not add CiliumNodeInternalIP from the k8sNodeAddress. The source
 		// of truth is always the local node. The CiliumInternalIP address is
@@ -471,6 +472,8 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 				Type: k8sAddress.Type,
 				IP:   k8sAddressStr,
 			})
+		} else {
+			oldCiliumNodeInternalIPs = append(oldCiliumNodeInternalIPs, k8sAddress.IP.String())
 		}
 	}
 
@@ -487,6 +490,16 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 			nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
 				Type: address.Type,
 				IP:   ciliumNodeAddress,
+			})
+		}
+	}
+	if len(n.localNode.IPAddresses) == 0 {
+		// If local CiliumNodeInternalIP is not synced yet, do not overwrite data in CN from k8s
+		log.Infof("Retaining old CiliumNodeInternalIP from CiliumNode since local data isn't available yet")
+		for _, ip := range oldCiliumNodeInternalIPs {
+			nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
+				Type: addressing.NodeCiliumInternalIP,
+				IP:   ip,
 			})
 		}
 	}


### PR DESCRIPTION
Cherry-picking https://github.com/DataDog/cilium/pull/517 into our 1.12 fork 