### PR TITLE
[runtime] Add fake release target

### DIFF
--- a/images/runtime/Dockerfile
+++ b/images/runtime/Dockerfile
@@ -70,4 +70,4 @@ RUN /test/bin/cst -C /test/bpftool
 RUN /test/bin/cst -C /test/iproute2
 
 # Datadog modification: do not squash the layers to not lose GBI labels
-FROM rootfs
+FROM rootfs as release


### PR DESCRIPTION
Gets use the same "release" target as used in:
* https://github.com/DataDog/cilium/blob/v1.13-dd/images/cilium/Dockerfile#L77 
* https://github.com/DataDog/cilium/blob/v1.13-dd/images/operator/Dockerfile#L58 

Instead of some gitlab complexity since, we've already forked this line. 