### PR TITLE
Fix restoreServicesLocked() potential nil pointer panic

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -975,6 +975,11 @@ func (s *Service) restoreServicesLocked(svcBackendsById map[lb.BackendID]struct{
 		}
 
 		for j, backend := range svc.Backends {
+			// DumpServiceMaps() can return services with some empty (nil) backends.
+			if backend == nil {
+				continue
+			}
+
 			hash := backend.L3n4Addr.Hash()
 			s.backendRefCount.Add(hash)
 			newSVC.backendByHash[hash] = svc.Backends[j]
@@ -989,6 +994,10 @@ func (s *Service) restoreServicesLocked(svcBackendsById map[lb.BackendID]struct{
 
 			backends := make(map[string]lb.BackendID, len(newSVC.backends))
 			for _, b := range newSVC.backends {
+				// DumpServiceMaps() can return services with some empty (nil) backends.
+				if b == nil {
+					continue
+				}
 				backends[b.String()] = b.ID
 			}
 			if err := s.lbmap.UpsertMaglevLookupTable(uint16(newSVC.frontend.ID), backends, ipv6); err != nil {


### PR DESCRIPTION
`1.11` backport of https://github.com/cilium/cilium/pull/23446 

```
goroutine 1 [running]:
github.com/cilium/cilium/pkg/service.(*Service).restoreServicesLocked(0xc00048c900, 0x0)
	/go/src/github.com/cilium/cilium/pkg/service/service.go:978 +0xbda
github.com/cilium/cilium/pkg/service.(*Service).RestoreServices(0xc00048c900)
	/go/src/github.com/cilium/cilium/pkg/service/service.go:496 +0xf4
github.com/cilium/cilium/daemon/cmd.NewDaemon({0x2f9f130, 0xc0008f8a40}, 0xc0008619c0, 0xc000436af0, {0x3006458, 0xc000101c80})
	/go/src/github.com/cilium/cilium/daemon/cmd/daemon.go:644 +0x257a
github.com/cilium/cilium/daemon/cmd.runDaemon()
	/go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1690 +0x7ce
github.com/cilium/cilium/daemon/cmd.glob..func1(0x4855380, {0x2accc30, 0x37, 0x37})
	/go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:127 +0x3ca
github.com/spf13/cobra.(*Command).execute(0x4855380, {0xc00011aa90, 0x37, 0x37})
	/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:860 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0x4855380)
	/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:902
github.com/cilium/cilium/daemon/cmd.Execute()
	/go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:141 +0x45
main.main()
	/go/src/github.com/cilium/cilium/daemon/main.go:16 +0x17
```