### PR TITLE
Add a debugger-enabled Cilium Agent image build to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,15 +13,19 @@ variables:
   id_tokens:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
+  variables:
+    TARGET: release
   script:
     - set -x
     - builder=$(docker buildx create --use)
     - trap "docker buildx rm $builder" EXIT
     # Construct valid --build-args arguments from the DOCKER_BUILD_ARGS variable
     - BUILD_ARGS=""; IFS=$'\n'; for arg in $DOCKER_BUILD_ARGS; do BUILD_ARGS+=" $(echo "--build-arg $arg")"; done; IFS=$' ';
-    - IMAGE_TAG="registry.ddbuild.io/$IMAGE_NAME:$CI_COMMIT_TAG"
+    - IMAGE_TAG="$CI_COMMIT_TAG"
+    - if [ "$TARGET" = "debug" ] ; then IMAGE_TAG="$IMAGE_TAG-debug" ; fi
+    - IMAGE_REF="registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG"
     - METADATA_FILE=$(mktemp)
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_TAG --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target release --push --metadata-file $METADATA_FILE $DOCKER_CONTEXT
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CONTEXT
     - ddsign sign $IMAGE_TAG --docker-metadata-file $METADATA_FILE
 
 build-docker-image-operator:
@@ -48,6 +52,18 @@ build-docker-image-cilium:
     # The cilium image depends on the runtime image
     - build-docker-image-runtime
   variables:
+    IMAGE_NAME: cilium
+    DOCKERFILE_PATH: images/cilium/Dockerfile
+    DOCKER_BUILD_ARGS: |
+      CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG
+
+build-docker-image-cilium-debug:
+  <<: *build-docker-image
+  needs:
+    # The debug image depends on the runtime image
+    - build-docker-image-runtime
+  variables:
+    TARGET: debug
     IMAGE_NAME: cilium
     DOCKERFILE_PATH: images/cilium/Dockerfile
     DOCKER_BUILD_ARGS: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ variables:
     - IMAGE_REF="registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG"
     - METADATA_FILE=$(mktemp)
     - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CONTEXT
-    - ddsign sign $IMAGE_TAG --docker-metadata-file $METADATA_FILE
+    - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE
 
 build-docker-image-operator:
   <<: *build-docker-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,10 @@ build-docker-image-cilium:
       CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG
     TARGET: release
 
+# Caveats:
+# * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In
+#   other words, the arm64 image does not work.
+# * Delve doesn't seem to work well in any case. For instance, `args` panics and `grs` doesn't work.
 build-docker-image-cilium-debug:
   <<: *build-docker-image
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,7 @@ build-docker-image-cilium-debug:
     DOCKERFILE_PATH: images/cilium/Dockerfile
     DOCKER_BUILD_ARGS: |
       CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG
+    NOSTRIP: 1
     TARGET: debug
 
 build-docker-image-hubble-relay:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,6 @@ variables:
   id_tokens:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
-  variables:
-    TARGET: release
   script:
     - set -x
     - builder=$(docker buildx create --use)
@@ -36,6 +34,7 @@ build-docker-image-operator:
     DOCKER_BUILD_ARGS: |
       BASE_IMAGE=registry.ddbuild.io/images/base/gbi-distroless:release
       OPERATOR_VARIANT=operator
+    TARGET: release
 
 build-docker-image-runtime:
   <<: *build-docker-image
@@ -45,6 +44,7 @@ build-docker-image-runtime:
     DOCKER_BUILD_ARGS: |
       UBUNTU_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
     DOCKER_CONTEXT: "./images/runtime"
+    TARGET: release
 
 build-docker-image-cilium:
   <<: *build-docker-image
@@ -56,6 +56,7 @@ build-docker-image-cilium:
     DOCKERFILE_PATH: images/cilium/Dockerfile
     DOCKER_BUILD_ARGS: |
       CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG
+    TARGET: release
 
 build-docker-image-cilium-debug:
   <<: *build-docker-image
@@ -63,11 +64,11 @@ build-docker-image-cilium-debug:
     # The debug image depends on the runtime image
     - build-docker-image-runtime
   variables:
-    TARGET: debug
     IMAGE_NAME: cilium
     DOCKERFILE_PATH: images/cilium/Dockerfile
     DOCKER_BUILD_ARGS: |
       CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG
+    TARGET: debug
 
 build-docker-image-hubble-relay:
   <<: *build-docker-image
@@ -76,3 +77,4 @@ build-docker-image-hubble-relay:
     DOCKERFILE_PATH: images/hubble-relay/Dockerfile
     DOCKER_BUILD_ARGS: |
       BASE_IMAGE=registry.ddbuild.io/images/base/gbi-distroless:release
+    TARGET: release

--- a/images/scripts/debug-wrapper.sh
+++ b/images/scripts/debug-wrapper.sh
@@ -11,4 +11,5 @@ set -o pipefail
     --log-output=debugger,debuglineerr,gdbwire,lldbout,rpc \
     --accept-multiclient \
     --api-version=2 \
+    --continue \
     exec "${0}-bin" -- "$@"

--- a/images/scripts/debug-wrapper.sh
+++ b/images/scripts/debug-wrapper.sh
@@ -11,5 +11,4 @@ set -o pipefail
     --log-output=debugger,debuglineerr,gdbwire,lldbout,rpc \
     --accept-multiclient \
     --api-version=2 \
-    --continue \
-    exec "${0}-bin" -- "$@"
+    exec --continue "${0}-bin" -- "$@"


### PR DESCRIPTION
Adds a debug image build that runs cilium-agent from delve.

```
root@eu1-staging-dog-throh-k8s-b7b99a8e3496f78d-ndld:/home/cilium# ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 14:53 ?        00:00:00 bash /usr/bin/cilium-agent --auto-create-cilium-node-resource=true --cluster-name=throh --cluster-id=43 --debug=false --pprof=true --enable-endpoint-routes=true --fixed-identity-mapping=128=etcd --fixed-identity-mapping=
root           7       1  0 14:53 ?        00:00:00 /usr/bin/dlv --listen=:2345 --headless=true --log=true --log-output=debugger,debuglineerr,gdbwire,lldbout,rpc --accept-multiclient --api-version=2 exec /usr/bin/cilium-agent-bin -- --auto-create-cilium-node-resource=true
root          13       7  0 14:53 ?        00:00:00 /usr/bin/cilium-agent-bin --auto-create-cilium-node-resource=true --cluster-name=throh --cluster-id=43 --debug=false --pprof=true --enable-endpoint-routes=true --fixed-identity-mapping=128=etcd --fixed-identity-mapping=1
root          26       0  0 14:55 pts/0    00:00:00 /bin/bash
root          34      26  0 14:55 pts/0    00:00:00 ps -ef
```
