### PR TITLE
Clean up stale definitions of EPHEMERAL_MIN in bpf/init.sh

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -392,6 +392,7 @@ case "${MODE}" in
 		CILIUM_IDX=$(cat "${SYSCLASSNETDIR}/${HOST_DEV1}/ifindex")
 		echo "#define CILIUM_IFINDEX $CILIUM_IDX" >> $RUNDIR/globals/node_config.h
 
+		sed -i '/^#.*EPHEMERAL_MIN.*$/d' $RUNDIR/globals/node_config.h
 		CILIUM_EPHEMERAL_MIN=$(cat "${PROCSYSNETDIR}/ipv4/ip_local_port_range" | awk '{print $1}')
 		echo "#define EPHEMERAL_MIN $CILIUM_EPHEMERAL_MIN" >> $RUNDIR/globals/node_config.h
 esac


### PR DESCRIPTION
```
root@<>:/var/run/cilium/state/globals# cat node_config.h | grep '#define EPHEMERAL_MIN 32768' -A5
#define EPHEMERAL_MIN 32768
#define EPHEMERAL_MIN 15000
#define EPHEMERAL_MIN 15000
#define EPHEMERAL_MIN 15000
#define EPHEMERAL_MIN 15000
#define EPHEMERAL_MIN 15000
```