### PR TITLE
Deliver Cilium debug symbols as separate files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ build-docker-image-cilium:
     - METADATA_FILE=$(mktemp)
     - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
     - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag ${IMAGE_REF}-debug-symbols --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug-symbols --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag ${IMAGE_REF}-debug-symbols --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug-symbols --target debug-symbols --push --metadata-file $METADATA_FILE $DOCKER_CTX
 
 # Caveats:
 # * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ build-docker-image-cilium:
     - METADATA_FILE=$(mktemp)
     - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
     - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug-symbols --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag ${IMAGE_REF}-debug-symbols --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug-symbols --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
 
 # Caveats:
 # * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,19 @@ build-docker-image-cilium:
       CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG
       CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:f229913ec72a183640bd46d0dd0579ebea3bb1c6@sha256:6ec80f7123cbf83008420b34c458f2e18e2091a648c0926ae3a601820468d902
       CILIUM_ENVOY_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.26-39dc41f86c465d2a2d16386339dc0bf4d425babc@sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5
+      NOSTRIP=1
     TARGET: release
+  script:
+    - set -x
+    # Construct valid --build-args arguments from the DOCKER_BUILD_ARGS variable
+    - BUILD_ARGS=""; IFS=$'\n'; for arg in $DOCKER_BUILD_ARGS; do BUILD_ARGS+=" $(echo "--build-arg $arg")"; done; IFS=$' ';
+    - IMAGE_TAG="$CI_COMMIT_TAG"
+    - if [ "$TARGET" = "debug" ] ; then IMAGE_TAG="$IMAGE_TAG-debug" ; fi
+    - IMAGE_REF="registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG"
+    - METADATA_FILE=$(mktemp)
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target builder $DOCKER_CTX
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
+    - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE
 
 # Caveats:
 # * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ build-docker-image-cilium:
     - METADATA_FILE=$(mktemp)
     - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
     - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag ${IMAGE_REF}-debug-symbols --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug-symbols --target debug-symbols --push --metadata-file $METADATA_FILE $DOCKER_CTX
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag ${IMAGE_REF}-debug-symbols --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=build --target debug-symbols --push --metadata-file $METADATA_FILE $DOCKER_CTX
 
 # Caveats:
 # * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,6 @@ build-docker-image-cilium:
       CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG
       CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:f229913ec72a183640bd46d0dd0579ebea3bb1c6@sha256:6ec80f7123cbf83008420b34c458f2e18e2091a648c0926ae3a601820468d902
       CILIUM_ENVOY_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.26-39dc41f86c465d2a2d16386339dc0bf4d425babc@sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5
-      NOSTRIP=1
     TARGET: release
   script:
     - set -x
@@ -78,9 +77,9 @@ build-docker-image-cilium:
     - if [ "$TARGET" = "debug" ] ; then IMAGE_TAG="$IMAGE_TAG-debug" ; fi
     - IMAGE_REF="registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG"
     - METADATA_FILE=$(mktemp)
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target builder $DOCKER_CTX
     - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
     - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug-symbols --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
 
 # Caveats:
 # * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ build-docker-image-cilium:
     - METADATA_FILE=$(mktemp)
     - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
     - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag ${IMAGE_REF}-debug-symbols --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=build --target debug-symbols --push --metadata-file $METADATA_FILE $DOCKER_CTX
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag ${IMAGE_REF}-debug-symbols --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug-symbols --target debug-symbols --push --metadata-file $METADATA_FILE $DOCKER_CTX
 
 # Caveats:
 # * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ build-docker-image-cilium:
       CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:f229913ec72a183640bd46d0dd0579ebea3bb1c6@sha256:6ec80f7123cbf83008420b34c458f2e18e2091a648c0926ae3a601820468d902
       CILIUM_ENVOY_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.26-39dc41f86c465d2a2d16386339dc0bf4d425babc@sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5
     TARGET: release
-    NOSTRIP: 0
+    NOSTRIP: 1
   script:
     - set -x
     # Construct valid --build-args arguments from the DOCKER_BUILD_ARGS variable

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,39 +72,19 @@ build-docker-image-cilium:
       CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:f229913ec72a183640bd46d0dd0579ebea3bb1c6@sha256:6ec80f7123cbf83008420b34c458f2e18e2091a648c0926ae3a601820468d902
       CILIUM_ENVOY_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.26-39dc41f86c465d2a2d16386339dc0bf4d425babc@sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5
     TARGET: release
-    NOSTRIP: 1
+    NOSTRIP: 0
   script:
     - set -x
     # Construct valid --build-args arguments from the DOCKER_BUILD_ARGS variable
     - BUILD_ARGS=""; IFS=$'\n'; for arg in $DOCKER_BUILD_ARGS; do BUILD_ARGS+=" $(echo "--build-arg $arg")"; done; IFS=$' ';
     - IMAGE_TAG="$CI_COMMIT_TAG"
-#    - if [ "$TARGET" = "debug" ] ; then IMAGE_TAG="$IMAGE_TAG-debug" ; fi
     - IMAGE_REF="registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG"
     - METADATA_FILE1=$(mktemp)
     - METADATA_FILE2=$(mktemp)
     - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE1 $DOCKER_CTX
     - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE1
-#    - docker buildx build --platform linux/amd64,linux/arm64 --tag ${IMAGE_REF}-debug-symbols --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug-symbols --target debug-symbols --push --metadata-file $METADATA_FILE $DOCKER_CTX
     - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF-debug --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug --target debug --push --metadata-file $METADATA_FILE2 $DOCKER_CTX
     - ddsign sign $IMAGE_REF-debug --docker-metadata-file $METADATA_FILE2
-
-# Caveats:
-# * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In
-#   other words, the arm64 image does not work.
-#build-docker-image-cilium-debug:
-#  <<: *build-docker-image
-#  needs:
-#    # The debug image depends on the runtime image
-#    - build-docker-image-runtime
-#  variables:
-#    IMAGE_NAME: cilium
-#    DOCKERFILE_PATH: images/cilium/Dockerfile
-#    DOCKER_BUILD_ARGS: |
-#      CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG
-#      CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:f229913ec72a183640bd46d0dd0579ebea3bb1c6@sha256:6ec80f7123cbf83008420b34c458f2e18e2091a648c0926ae3a601820468d902
-#      CILIUM_ENVOY_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.26-39dc41f86c465d2a2d16386339dc0bf4d425babc@sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5
-#      NOSTRIP=1
-#    TARGET: debug
 
 build-docker-image-hubble-relay:
   <<: *build-docker-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,9 @@ build-docker-image-runtime:
     DOCKER_CTX: "./images/runtime"
     TARGET: release
 
+# Caveats:
+# * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In
+#   other words, the arm64 image does not work.
 build-docker-image-cilium:
   <<: *build-docker-image
   needs:
@@ -69,35 +72,39 @@ build-docker-image-cilium:
       CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:f229913ec72a183640bd46d0dd0579ebea3bb1c6@sha256:6ec80f7123cbf83008420b34c458f2e18e2091a648c0926ae3a601820468d902
       CILIUM_ENVOY_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.26-39dc41f86c465d2a2d16386339dc0bf4d425babc@sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5
     TARGET: release
+    NOSTRIP: 0
   script:
     - set -x
     # Construct valid --build-args arguments from the DOCKER_BUILD_ARGS variable
     - BUILD_ARGS=""; IFS=$'\n'; for arg in $DOCKER_BUILD_ARGS; do BUILD_ARGS+=" $(echo "--build-arg $arg")"; done; IFS=$' ';
     - IMAGE_TAG="$CI_COMMIT_TAG"
-    - if [ "$TARGET" = "debug" ] ; then IMAGE_TAG="$IMAGE_TAG-debug" ; fi
+#    - if [ "$TARGET" = "debug" ] ; then IMAGE_TAG="$IMAGE_TAG-debug" ; fi
     - IMAGE_REF="registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG"
-    - METADATA_FILE=$(mktemp)
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
-    - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag ${IMAGE_REF}-debug-symbols --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug-symbols --target debug-symbols --push --metadata-file $METADATA_FILE $DOCKER_CTX
+    - METADATA_FILE1=$(mktemp)
+    - METADATA_FILE2=$(mktemp)
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE1 $DOCKER_CTX
+    - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE1
+#    - docker buildx build --platform linux/amd64,linux/arm64 --tag ${IMAGE_REF}-debug-symbols --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug-symbols --target debug-symbols --push --metadata-file $METADATA_FILE $DOCKER_CTX
+    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF-debug --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug --target debug --push --metadata-file $METADATA_FILE2 $DOCKER_CTX
+    - ddsign sign $IMAGE_REF-debug --docker-metadata-file $METADATA_FILE2
 
 # Caveats:
 # * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In
 #   other words, the arm64 image does not work.
-build-docker-image-cilium-debug:
-  <<: *build-docker-image
-  needs:
-    # The debug image depends on the runtime image
-    - build-docker-image-runtime
-  variables:
-    IMAGE_NAME: cilium
-    DOCKERFILE_PATH: images/cilium/Dockerfile
-    DOCKER_BUILD_ARGS: |
-      CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG
-      CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:f229913ec72a183640bd46d0dd0579ebea3bb1c6@sha256:6ec80f7123cbf83008420b34c458f2e18e2091a648c0926ae3a601820468d902
-      CILIUM_ENVOY_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.26-39dc41f86c465d2a2d16386339dc0bf4d425babc@sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5
-      NOSTRIP=1
-    TARGET: debug
+#build-docker-image-cilium-debug:
+#  <<: *build-docker-image
+#  needs:
+#    # The debug image depends on the runtime image
+#    - build-docker-image-runtime
+#  variables:
+#    IMAGE_NAME: cilium
+#    DOCKERFILE_PATH: images/cilium/Dockerfile
+#    DOCKER_BUILD_ARGS: |
+#      CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG
+#      CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:f229913ec72a183640bd46d0dd0579ebea3bb1c6@sha256:6ec80f7123cbf83008420b34c458f2e18e2091a648c0926ae3a601820468d902
+#      CILIUM_ENVOY_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.26-39dc41f86c465d2a2d16386339dc0bf4d425babc@sha256:e77adfe8a263fe4b8c56dcb9bd0f4d68bb36067602e7be1388528c02fb8765c5
+#      NOSTRIP=1
+#    TARGET: debug
 
 build-docker-image-hubble-relay:
   <<: *build-docker-image

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -58,8 +58,8 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
     DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} install-bash-completion licenses-all && \
     mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
-RUN export S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
-    export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
+RUN S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
+    D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
     mkdir -p $D && \
     cd $S && \
     find . -type f \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -47,25 +47,25 @@ ARG LIBNETWORK_PLUGIN
 #
 WORKDIR /go/src/github.com/cilium/cilium
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
-    make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} PKG_BUILD=1 V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
+    make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=1 NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} PKG_BUILD=1 V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
     DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} build-container install-container-binary
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     # install-bash-completion will execute the bash_completion script. It is
     # fine to run this with same architecture as BUILDARCH since the output of
     # bash_completion is the same for both architectures.
-    make GOARCH=${BUILDARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} PKG_BUILD=1 V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
+    make GOARCH=${BUILDARCH} RACE=${RACE} NOSTRIP=1 NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} PKG_BUILD=1 V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
     DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} install-bash-completion licenses-all && \
     mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
-RUN cd /tmp/install/${TARGETOS}/${TARGETARCH} && \
-    S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
+RUN S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
     D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
     mkdir -p $D && \
+    cd $S && \
     find -type f \
       -executable \
       -exec sh -c \
-        'objcopy --only-keep-debug $0 $0.debug && objcopy --strip-debug $0 && objcopy --add-gnu-debuglink=$0.debug $0 && mkdir -p $D/$(dirname $0) && cp ${0}.debug $D/$0.debug' {} \;
+        'objcopy --only-keep-debug $0 $0.debug && if [ $NOSTRIP -ne 1 ] ; then objcopy --strip-debug $0 ; fi && objcopy --add-gnu-debuglink=$0.debug $0 && mkdir -p $D/$(dirname $0) && cp ${0}.debug $D/$0.debug' {} \;
 
 COPY images/cilium/init-container.sh \
      plugins/cilium-cni/cni-install.sh \
@@ -119,3 +119,14 @@ ARG TARGETARCH
 COPY --from=builder /go/bin/dlv /usr/bin/dlv
 RUN mv /usr/bin/cilium-agent /usr/bin/cilium-agent-bin
 COPY images/scripts/debug-wrapper.sh /usr/bin/cilium-agent
+
+#
+# Cilium debug symbols image.
+#
+FROM builder as debug-symbols
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+LABEL maintainer="maintainer@cilium.io"
+COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -58,13 +58,15 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
     DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} install-bash-completion licenses-all && \
     mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
-RUN export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
+RUN set -xe && \
+    export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
     mkdir -p $D && \
     cd /tmp/install/${TARGETOS}/${TARGETARCH} && \
     find . -type f \
       -executable \
       -exec sh -c \
-        'objcopy --only-keep-debug $0 $0.debug && \
+        'go tool buildid $0 && \
+          objcopy --only-keep-debug $0 $0.debug && \
           if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-all $0 && objcopy --add-gnu-debuglink=$0.debug $0 ; fi && \
           mkdir -p $D/$(dirname $0) && \
           mv -v ${0}.debug $D/$0.debug' \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -130,7 +130,7 @@ RUN if [ "$NOSTRIP" != "1" ] ; then \
         find . -type f \
           -executable \
           -exec sh -c \
-            'mv -v ${0} $(dirname $0)' \
+            'mv -v ${0} /$(dirname $0)' \
           {} \; \
     ; fi
 

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -126,22 +126,3 @@ COPY images/scripts/debug-wrapper.sh /usr/bin/cilium-agent
 
 # Copy in the debug symbols in case the binaries were stripped
 COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /usr/lib/debug
-#RUN if [ "$NOSTRIP" != "1" ] ; then \
-#        cd /tmp/debug && \
-#        find . -type f \
-#          -executable \
-#          -exec sh -c \
-#            'mv -v ${0} /$(dirname $0)' \
-#          {} \; \
-#    ; fi
-
-#
-# Cilium debug symbols image.
-#
-#FROM scratch as debug-symbols
-## TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
-#ARG TARGETOS
-## TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
-#ARG TARGETARCH
-#LABEL maintainer="maintainer@cilium.io"
-#COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -65,9 +65,10 @@ RUN set -xe && \
     find . -type f \
       -executable \
       -exec sh -c \
-        'objcopy --only-keep-debug $0 $0.debug && \
-          if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-all $0 && objcopy --add-gnu-debuglink=$0.debug $0 ; fi && \
-          mv -v ${0}.debug $D/$0.debug' \
+        'filename=$(basename ${0}) && \
+         objcopy --only-keep-debug ${0} ${0}.debug && \
+         if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-all ${0} && objcopy --add-gnu-debuglink=${filename}.debug ${0} ; fi && \
+         mv -v ${0}.debug ${D}/${filename}.debug' \
       {} \;
 
 COPY images/cilium/init-container.sh \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -65,7 +65,9 @@ RUN S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
     find -type f \
       -executable \
       -exec sh -c \
-        'objcopy --only-keep-debug $0 $0.debug && if [ $NOSTRIP -ne 1 ] ; then objcopy --strip-debug $0 ; fi && objcopy --add-gnu-debuglink=$0.debug $0 && mkdir -p $D/$(dirname $0) && cp ${0}.debug $D/$0.debug' {} \;
+        'objcopy --only-keep-debug $0 $0.debug && if [ $NOSTRIP -ne 1 ] ; then objcopy --strip-debug $0 ; fi && objcopy --add-gnu-debuglink=$0.debug $0 && mkdir -p $D/$(dirname $0) && mv ${0}.debug $D/$0.debug' {} \;
+
+RUN find /tmp/debug
 
 COPY images/cilium/init-container.sh \
      plugins/cilium-cni/cni-install.sh \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -66,8 +66,9 @@ RUN set -xe && \
       -executable \
       -exec sh -c \
         'filename=$(basename ${0}) && \
+         echo objcopy --only-keep-debug ${0} ${0}.debug && \
          objcopy --only-keep-debug ${0} ${0}.debug && \
-         if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-all ${0} && (cd $(dirname ${0}) && objcopy --add-gnu-debuglink=${filename}.debug ${0}) ; fi && \
+         if [ "$NOSTRIP" != "1" ] ; then echo objcopy --strip-all ${0} && objcopy --strip-all ${0} && echo cd $(dirname ${0}) && echo objcopy --add-gnu-debuglink=${filename}.debug ${0} && (cd $(dirname ${0}) && objcopy --add-gnu-debuglink=${filename}.debug ${0}) ; fi && \
          mv -v ${0}.debug ${D}/${filename}.debug' \
       {} \;
 

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -127,5 +127,6 @@ COPY images/scripts/debug-wrapper.sh /usr/bin/cilium-agent
 # Copy in the debug symbols in case the binaries were stripped
 COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /usr/lib/debug
 
-# Ensure dlv finds the debug symbols. Due to CGO_ENABLED=0, we have no GNU build-id.
-RUN sed -i -e 's!"/usr/lib/debug/.build-id"!"/usr/lib/debug/.build-id", "/usr/lib/debug"!' ~/.config/dlv/config.yml
+# Ensure dlv finds the debug symbols. Due to CGO_ENABLED=0, we have no GNU build-id, so Delve's default configuration
+# is insufficient.
+RUN echo 'debug-info-directories: ["/usr/lib/debug/.build-id","/usr/lib/debug"]' > ~/.config/dlv/config.yml

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -58,6 +58,15 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
     DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} install-bash-completion licenses-all && \
     mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
+RUN cd /tmp/install/${TARGETOS}/${TARGETARCH} && \
+    S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
+    D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
+    mkdir -p $D && \
+    find -type f \
+      -executable \
+      -exec sh -c \
+        'objcopy --only-keep-debug $0 $0.debug && objcopy --strip-debug $0 && objcopy --add-gnu-debuglink=$0.debug $0 && mkdir -p $D/$(dirname $0) && cp ${0}.debug $D/$0.debug' {} \;
+
 COPY images/cilium/init-container.sh \
      plugins/cilium-cni/cni-install.sh \
      plugins/cilium-cni/install-plugin.sh \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -58,8 +58,6 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
     DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} install-bash-completion licenses-all && \
     mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
-RUN find /tmp/install/${TARGETOS}/${TARGETARCH} -ls
-
 RUN export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
     mkdir -p $D && \
     cd /tmp/install/${TARGETOS}/${TARGETARCH} && \
@@ -71,9 +69,6 @@ RUN export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
           mkdir -p $D/$(dirname $0) && \
           mv -v ${0}.debug $D/$0.debug' \
       {} \;
-
-RUN find /tmp/install/${TARGETOS}/${TARGETARCH} -ls
-RUN find /tmp/debug/${TARGETOS}/${TARGETARCH} -ls
 
 COPY images/cilium/init-container.sh \
      plugins/cilium-cni/cni-install.sh \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -69,7 +69,7 @@ RUN export S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
           if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-debug $0 ; fi && \
           objcopy --add-gnu-debuglink=$0.debug $0 && \
           mkdir -p $D/$(dirname $0) && \
-          mv ${0}.debug $D/$0.debug' \
+          mv -v ${0}.debug $D/$0.debug' \
       {} \;
 
 COPY images/cilium/init-container.sh \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -67,8 +67,7 @@ RUN export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
       -executable \
       -exec sh -c \
         'objcopy --only-keep-debug $0 $0.debug && \
-          if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-debug $0 ; fi && \
-          objcopy --add-gnu-debuglink=$0.debug $0 && \
+          if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-debug $0 && objcopy --add-gnu-debuglink=$0.debug $0 ; fi && \
           mkdir -p $D/$(dirname $0) && \
           mv -v ${0}.debug $D/$0.debug' \
       {} \;

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -123,7 +123,7 @@ COPY images/scripts/debug-wrapper.sh /usr/bin/cilium-agent
 #
 # Cilium debug symbols image.
 #
-FROM ${CILIUM_RUNTIME_IMAGE} as debug-symbols
+FROM scratch as debug-symbols
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -66,9 +66,8 @@ RUN set -xe && \
       -executable \
       -exec sh -c \
         'filename=$(basename ${0}) && \
-         echo objcopy --only-keep-debug ${0} ${0}.debug && \
          objcopy --only-keep-debug ${0} ${0}.debug && \
-         if [ "$NOSTRIP" != "1" ] ; then echo objcopy --strip-all ${0} && objcopy --strip-all ${0} && echo cd $(dirname ${0}) && echo objcopy --add-gnu-debuglink=${filename}.debug ${filename} && (cd $(dirname ${0}) && objcopy --add-gnu-debuglink=${filename}.debug ${filename}) ; fi && \
+         if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-all ${0} && (cd $(dirname ${0}) && objcopy --add-gnu-debuglink=${filename}.debug ${filename}) ; fi && \
          mv -v ${0}.debug ${D}/${filename}.debug' \
       {} \;
 

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -127,6 +127,7 @@ COPY images/scripts/debug-wrapper.sh /usr/bin/cilium-agent
 # Copy in the debug symbols in case the binaries were stripped
 COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /usr/lib/debug
 
-# Ensure dlv finds the debug symbols. Due to CGO_ENABLED=0, we have no GNU build-id, so Delve's default configuration
+# Ensure dlv finds the debug symbols. Due to CGO_ENABLED=0, we have no GNU build-id, so Delve's default search path
 # is insufficient.
-RUN echo 'debug-info-directories: ["/usr/lib/debug/.build-id","/usr/lib/debug"]' > ~/.config/dlv/config.yml
+RUN mkdir -p ${HOME}/.config/dlv && \
+    echo 'debug-info-directories: ["/usr/lib/debug/.build-id","/usr/lib/debug"]' > ${HOME}/.config/dlv/config.yml

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -126,3 +126,6 @@ COPY images/scripts/debug-wrapper.sh /usr/bin/cilium-agent
 
 # Copy in the debug symbols in case the binaries were stripped
 COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /usr/lib/debug
+
+# Ensure dlv finds the debug symbols. Due to CGO_ENABLED=0, we have no GNU build-id.
+RUN sed -i -e 's!"/usr/lib/debug/.build-id"!"/usr/lib/debug/.build-id", "/usr/lib/debug"!' ~/.config/dlv/config.yml

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -130,4 +130,5 @@ COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /usr/lib/debug
 # Ensure dlv finds the debug symbols. Due to CGO_ENABLED=0, we have no GNU build-id, so Delve's default search path
 # is insufficient.
 RUN mkdir -p ${HOME}/.config/dlv && \
-    echo 'debug-info-directories: ["/usr/lib/debug/.build-id","/usr/lib/debug"]' > ${HOME}/.config/dlv/config.yml
+    echo 'debug-info-directories: ["/usr/lib/debug/.build-id","/usr/lib/debug"]' > ${HOME}/.config/dlv/config.yml && \
+    ln -s /usr/lib/debug/cilium-agent.debug /usr/lib/debug/cilium-agent-bin.debug

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -65,7 +65,7 @@ RUN S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
     find -type f \
       -executable \
       -exec sh -c \
-        'objcopy --only-keep-debug $0 $0.debug && if [ $NOSTRIP -ne 1 ] ; then objcopy --strip-debug $0 ; fi && objcopy --add-gnu-debuglink=$0.debug $0 && mkdir -p $D/$(dirname $0) && mv ${0}.debug $D/$0.debug' {} \;
+        'objcopy --only-keep-debug $0 $0.debug && if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-debug $0 ; fi && objcopy --add-gnu-debuglink=$0.debug $0 && mkdir -p $D/$(dirname $0) && mv ${0}.debug $D/$0.debug' {} \;
 
 RUN find /tmp/debug
 

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -65,11 +65,8 @@ RUN set -xe && \
     find . -type f \
       -executable \
       -exec sh -c \
-        'go tool buildid $0 &&  \
-          readelf -n $0 && \
-          objcopy --only-keep-debug $0 $0.debug && \
+        'objcopy --only-keep-debug $0 $0.debug && \
           if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-all $0 && objcopy --add-gnu-debuglink=$0.debug $0 ; fi && \
-          mkdir -p $D/$(dirname $0) && \
           mv -v ${0}.debug $D/$0.debug' \
       {} \;
 

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -67,8 +67,6 @@ RUN export S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
       -exec sh -c \
         'objcopy --only-keep-debug $0 $0.debug && if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-debug $0 ; fi && objcopy --add-gnu-debuglink=$0.debug $0 && mkdir -p $D/$(dirname $0) && mv ${0}.debug $D/$0.debug' {} \;
 
-RUN find /tmp/debug
-
 COPY images/cilium/init-container.sh \
      plugins/cilium-cni/cni-install.sh \
      plugins/cilium-cni/install-plugin.sh \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -58,10 +58,11 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
     DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} install-bash-completion licenses-all && \
     mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
-RUN S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
-    D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
+RUN find /tmp/install/${TARGETOS}/${TARGETARCH} -ls
+
+RUN export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
     mkdir -p $D && \
-    cd $S && \
+    cd /tmp/install/${TARGETOS}/${TARGETARCH} && \
     find . -type f \
       -executable \
       -exec sh -c \
@@ -71,6 +72,9 @@ RUN S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
           mkdir -p $D/$(dirname $0) && \
           mv -v ${0}.debug $D/$0.debug' \
       {} \;
+
+RUN find /tmp/install/${TARGETOS}/${TARGETARCH} -ls
+RUN find /tmp/debug/${TARGETOS}/${TARGETARCH} -ls
 
 COPY images/cilium/init-container.sh \
      plugins/cilium-cni/cni-install.sh \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -59,14 +59,14 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
     mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
 RUN set -xe && \
-    (readelf -n /tmp/install/${TARGETOS}/${TARGETARCH}/usr/bin/cilium || true) && \
     export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
     mkdir -p $D && \
     cd /tmp/install/${TARGETOS}/${TARGETARCH} && \
     find . -type f \
       -executable \
       -exec sh -c \
-        'go tool buildid $0 && \
+        'go tool buildid $0 &&  \
+          readelf -n $0 && \
           objcopy --only-keep-debug $0 $0.debug && \
           if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-all $0 && objcopy --add-gnu-debuglink=$0.debug $0 ; fi && \
           mkdir -p $D/$(dirname $0) && \
@@ -126,16 +126,16 @@ COPY --from=builder /go/bin/dlv /usr/bin/dlv
 RUN mv /usr/bin/cilium-agent /usr/bin/cilium-agent-bin
 COPY images/scripts/debug-wrapper.sh /usr/bin/cilium-agent
 
-# If binaries were stripped, i.e. NOSTRIP!=1, we copy the debug symbols from the builder image
-COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /tmp/debug
-RUN if [ "$NOSTRIP" != "1" ] ; then \
-        cd /tmp/debug && \
-        find . -type f \
-          -executable \
-          -exec sh -c \
-            'mv -v ${0} /$(dirname $0)' \
-          {} \; \
-    ; fi
+# Copy in the debug symbols in case the binaries were stripped
+COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /usr/lib/debug
+#RUN if [ "$NOSTRIP" != "1" ] ; then \
+#        cd /tmp/debug && \
+#        find . -type f \
+#          -executable \
+#          -exec sh -c \
+#            'mv -v ${0} /$(dirname $0)' \
+#          {} \; \
+#    ; fi
 
 #
 # Cilium debug symbols image.

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -65,7 +65,12 @@ RUN export S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
     find . -type f \
       -executable \
       -exec sh -c \
-        'objcopy --only-keep-debug $0 $0.debug && if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-debug $0 ; fi && objcopy --add-gnu-debuglink=$0.debug $0 && mkdir -p $D/$(dirname $0) && mv ${0}.debug $D/$0.debug' {} \;
+        'objcopy --only-keep-debug $0 $0.debug && \
+          if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-debug $0 ; fi && \
+          objcopy --add-gnu-debuglink=$0.debug $0 && \
+          mkdir -p $D/$(dirname $0) && \
+          mv ${0}.debug $D/$0.debug' \
+      {} \;
 
 COPY images/cilium/init-container.sh \
      plugins/cilium-cni/cni-install.sh \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -59,6 +59,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
     mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
 RUN set -xe && \
+    (readelf -n /tmp/install/${TARGETOS}/${TARGETARCH}/usr/bin/cilium || true) && \
     export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
     mkdir -p $D && \
     cd /tmp/install/${TARGETOS}/${TARGETARCH} && \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -65,7 +65,7 @@ RUN export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
       -executable \
       -exec sh -c \
         'objcopy --only-keep-debug $0 $0.debug && \
-          if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-debug $0 && objcopy --add-gnu-debuglink=$0.debug $0 ; fi && \
+          if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-all $0 && objcopy --add-gnu-debuglink=$0.debug $0 ; fi && \
           mkdir -p $D/$(dirname $0) && \
           mv -v ${0}.debug $D/$0.debug' \
       {} \;
@@ -122,6 +122,17 @@ ARG TARGETARCH
 COPY --from=builder /go/bin/dlv /usr/bin/dlv
 RUN mv /usr/bin/cilium-agent /usr/bin/cilium-agent-bin
 COPY images/scripts/debug-wrapper.sh /usr/bin/cilium-agent
+
+# If binaries were stripped, i.e. NOSTRIP!=1, we copy the debug symbols from the builder image
+COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /tmp/debug
+RUN if [ "$NOSTRIP" != "1" ] ; then \
+        cd /tmp/debug && \
+        find . -type f \
+          -executable \
+          -exec sh -c \
+            'mv -v ${0} $(dirname $0)' \
+          {} \; \
+    ; fi
 
 #
 # Cilium debug symbols image.

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -68,7 +68,7 @@ RUN set -xe && \
         'filename=$(basename ${0}) && \
          echo objcopy --only-keep-debug ${0} ${0}.debug && \
          objcopy --only-keep-debug ${0} ${0}.debug && \
-         if [ "$NOSTRIP" != "1" ] ; then echo objcopy --strip-all ${0} && objcopy --strip-all ${0} && echo cd $(dirname ${0}) && echo objcopy --add-gnu-debuglink=${filename}.debug ${0} && (cd $(dirname ${0}) && objcopy --add-gnu-debuglink=${filename}.debug ${0}) ; fi && \
+         if [ "$NOSTRIP" != "1" ] ; then echo objcopy --strip-all ${0} && objcopy --strip-all ${0} && echo cd $(dirname ${0}) && echo objcopy --add-gnu-debuglink=${filename}.debug ${filename} && (cd $(dirname ${0}) && objcopy --add-gnu-debuglink=${filename}.debug ${filename}) ; fi && \
          mv -v ${0}.debug ${D}/${filename}.debug' \
       {} \;
 

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -67,7 +67,7 @@ RUN set -xe && \
       -exec sh -c \
         'filename=$(basename ${0}) && \
          objcopy --only-keep-debug ${0} ${0}.debug && \
-         if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-all ${0} && objcopy --add-gnu-debuglink=${filename}.debug ${0} ; fi && \
+         if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-all ${0} && (cd $(dirname ${0}) && objcopy --add-gnu-debuglink=${filename}.debug ${0}) ; fi && \
          mv -v ${0}.debug ${D}/${filename}.debug' \
       {} \;
 

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -62,7 +62,7 @@ RUN export S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
     export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
     mkdir -p $D && \
     cd $S && \
-    find -type f \
+    find . -type f \
       -executable \
       -exec sh -c \
         'objcopy --only-keep-debug $0 $0.debug && if [ "$NOSTRIP" != "1" ] ; then objcopy --strip-debug $0 ; fi && objcopy --add-gnu-debuglink=$0.debug $0 && mkdir -p $D/$(dirname $0) && mv ${0}.debug $D/$0.debug' {} \;

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -137,10 +137,10 @@ RUN if [ "$NOSTRIP" != "1" ] ; then \
 #
 # Cilium debug symbols image.
 #
-FROM scratch as debug-symbols
-# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
-ARG TARGETOS
-# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
-ARG TARGETARCH
-LABEL maintainer="maintainer@cilium.io"
-COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /
+#FROM scratch as debug-symbols
+## TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+#ARG TARGETOS
+## TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+#ARG TARGETARCH
+#LABEL maintainer="maintainer@cilium.io"
+#COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -58,8 +58,8 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
     DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} install-bash-completion licenses-all && \
     mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
-RUN S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
-    D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
+RUN export S=/tmp/install/${TARGETOS}/${TARGETARCH} && \
+    export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
     mkdir -p $D && \
     cd $S && \
     find -type f \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -123,7 +123,7 @@ COPY images/scripts/debug-wrapper.sh /usr/bin/cilium-agent
 #
 # Cilium debug symbols image.
 #
-FROM builder as debug-symbols
+FROM ${CILIUM_RUNTIME_IMAGE} as debug-symbols
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Provides debug symbols and ensures `release` and `debug` binaries are from the same build - so symbol files always match.

- If the build is invoked with `NOSTRIP=0`, then the `release` image has stripped binaries and the `debug` image has stripped binaries + debug symbol files in `/usr/lib/debug`.
- If the build is invoked with `NOSTRIP=1`, then the `release` image has non-stripped binaries and the `debug` image has non-stripped binaries + debug symbol files in `/usr/lib/debug`.

The latter is somewhat redundant in the `debug` image since the debug symbols are present both in the binaires and in `/usr/lib/debug`. I'm hoping this will be acceptable upstream.

Part of the idea is that we should no longer need to touch `NOSTRIP`. In our current builds, the problem is that both our `release` and `debug` builds are lacking symbols by default. To get builds with symbols, we need to go and hack `.gitlab-ci.yml` and flip `NOSTRIP`, branch, tag and push. We can’t use our default `debug` images because they have no symbols, so delve doesn’t understand anything about the binary it’s running.

With this change, all tagged builds deliver a `release` image that is either stripped or not according to `NOSTRIP` (so stripped with our default `.gitlab-ci.yml`), and a `debug` image that includes the symbol files.
So the `debug` image works: delve understands the binary, you can do remote debugging from your IDE with port-forward etc.

Also, by systematically delivering the debug symbol files in the `debug` image in `/usr/lib/debug`, it makes it easy to split them out for post-processing. If, for instance, I didn’t include the debug files in the non-stripped version of the `debug` image, then it would be harder to identify the files that should be post-processed.

So I think this strikes a good balance in terms of making it easy to know where to find debug symbols and something I hope upstream should be OK with (it improves usability of the `debug` image, since currently if `NOSTRIP=0`, then the `debug` image has no symbols and it’s useless with Delve and Co).

I'd like to merge this in our fork for now so that we can continue experimenting with this whilst I try to upstream equivalent changes to `main`.