### PR TITLE
Bump CRD version

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -23,7 +23,7 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.26.8"
+	CustomResourceDefinitionSchemaVersion = "1.26.9"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"


### PR DESCRIPTION
Follow-up to https://github.com/DataDog/cilium/pull/551

Someone bumped the version in f0f2afb0e9 right before I merged the PR, so re-bumping it again.