### PR TITLE
kvstoremesh: Add logging configuration options

### DIFF
--- a/kvstoremesh/main.go
+++ b/kvstoremesh/main.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	kmmetrics "github.com/cilium/cilium/kvstoremesh/metrics"
@@ -44,8 +43,8 @@ var (
 			// Overwrite the metrics namespace with the one specific for KVStoreMesh
 			metrics.Namespace = metrics.CiliumKVStoreMeshNamespace
 			option.Config.Populate(rootHive.Viper())
-			if option.Config.Debug {
-				log.Logger.SetLevel(logrus.DebugLevel)
+			if err := logging.SetupLogging(option.Config.LogDriver, option.Config.LogOpt, "kvstoremesh", option.Config.Debug); err != nil {
+				log.Fatal(err)
 			}
 			option.LogRegisteredOptions(rootHive.Viper(), log)
 		},

--- a/kvstoremesh/option/config.go
+++ b/kvstoremesh/option/config.go
@@ -23,10 +23,15 @@ type KVStoreMeshConfig struct {
 
 	ClusterName string
 	ClusterID   uint32
+
+	LogDriver []string
+	LogOpt    map[string]string
 }
 
 func (def KVStoreMeshConfig) Flags(flags *pflag.FlagSet) {
 	flags.BoolP(option.DebugArg, "D", def.Debug, "Enable debugging mode")
 	flags.String(option.ClusterName, def.ClusterName, "Name of the cluster")
 	flags.Uint32(option.ClusterIDName, def.ClusterID, "Unique identifier of the cluster")
+	flags.StringSlice(option.LogDriver, def.LogDriver, "Logging driver to use")
+	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil), option.LogOpt, "Logger options")
 }


### PR DESCRIPTION
# Description
Added two new options to the `kvstoremesh` binary: `--log-driver` and `--log-opt` so that we can use the `logging.SetupLogging()` function.
The `Debug` functionality stays the same.

# Testing
Built a new image and re-deployed the `kvstoremesh` with `--log-opt=format=json-ts`.
Verified that this worked:
```
$ kubectl logs cilium-kvstoremesh-7976b7477f-hb484
{"level":"info","msg":"  --cluster-id='1'","subsys":"kvstoremesh","time":"2024-05-16T15:12:50.75960323Z"}
{"level":"info","msg":"  --cluster-name='cluster1'","subsys":"kvstoremesh","time":"2024-05-16T15:12:50.759714087Z"}
{"level":"info","msg":"  --clustermesh-config='/var/lib/cilium/clustermesh'","subsys":"kvstoremesh","time":"2024-05-16T15:12:50.759736339Z"}
[...]
```