### PR TITLE
Rebuild images on a schedule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,21 +12,14 @@ before_script:
   image: $CI_DOCKER_IMAGE
   tags: ["arch:arm64"]
   rules:
-    # Automatically run the pipeline for all pushed tags
+    # Run the pipeline for all pushed tags + schedules
     - if: $CI_COMMIT_TAG
+    - if: $CI_PIPELINE_SOURCE == "schedule"
   id_tokens:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
   script:
-    - set -x
-    # Construct valid --build-args arguments from the DOCKER_BUILD_ARGS variable
-    - BUILD_ARGS=""; IFS=$'\n'; for arg in $DOCKER_BUILD_ARGS; do BUILD_ARGS+=" $(echo "--build-arg $arg")"; done; IFS=$' ';
-    - IMAGE_TAG="$CI_COMMIT_TAG"
-    - if [ "$TARGET" = "debug" ] ; then IMAGE_TAG="$IMAGE_TAG-debug" ; fi
-    - IMAGE_REF="registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG"
-    - METADATA_FILE=$(mktemp)
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE $DOCKER_CTX
-    - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE
+    - .gitlab/build-image.sh
 
 build-docker-image-operator:
   <<: *build-docker-image
@@ -68,23 +61,12 @@ build-docker-image-cilium:
     IMAGE_NAME: cilium
     DOCKERFILE_PATH: images/cilium/Dockerfile
     DOCKER_BUILD_ARGS: |
-      CILIUM_RUNTIME_IMAGE=registry.ddbuild.io/cilium-runtime:$CI_COMMIT_TAG
       CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:c9a0fac9eaf925a150a055c43592f283868ba2b1@sha256:9cdc6e2e3c3dedc798c71672811b7cfa67d2c7b6d6e3046d917b9c4483c1a065
       CILIUM_ENVOY_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.29.7-39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51@sha256:bd5ff8c66716080028f414ec1cb4f7dc66f40d2fb5a009fff187f4a9b90b566b
     TARGET: release
     NOSTRIP: 0
   script:
-    - set -x
-    # Construct valid --build-args arguments from the DOCKER_BUILD_ARGS variable
-    - BUILD_ARGS=""; IFS=$'\n'; for arg in $DOCKER_BUILD_ARGS; do BUILD_ARGS+=" $(echo "--build-arg $arg")"; done; IFS=$' ';
-    - IMAGE_TAG="$CI_COMMIT_TAG"
-    - IMAGE_REF="registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG"
-    - METADATA_FILE1=$(mktemp)
-    - METADATA_FILE2=$(mktemp)
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=prod --target $TARGET --push --metadata-file $METADATA_FILE1 $DOCKER_CTX
-    - ddsign sign $IMAGE_REF --docker-metadata-file $METADATA_FILE1
-    - docker buildx build --platform linux/amd64,linux/arm64 --tag $IMAGE_REF-debug --file $DOCKERFILE_PATH $BUILD_ARGS --label CILIUM_VERSION=$(cat VERSION) --label target=debug --target debug --push --metadata-file $METADATA_FILE2 $DOCKER_CTX
-    - ddsign sign $IMAGE_REF-debug --docker-metadata-file $METADATA_FILE2
+    - .gitlab/build-image.sh
 
 build-docker-image-hubble-relay:
   <<: *build-docker-image

--- a/.gitlab/build-image.sh
+++ b/.gitlab/build-image.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+# Construct valid --build-args arguments from the DOCKER_BUILD_ARGS variable
+BUILD_ARGS=""
+IFS=$'\n'
+for arg in $DOCKER_BUILD_ARGS; do
+  BUILD_ARGS+=" $(echo "--build-arg $arg")"
+done
+IFS=$' '
+
+# Build 3 latest git tags when the pipeline is triggered by a schedule, otherwise build the latest tag
+N_GIT_TAGS_TO_BUILD=1
+if [ "$CI_PIPELINE_SOURCE" == "schedule" ]; then
+  N_GIT_TAGS_TO_BUILD=3
+fi
+
+# Get the N_GIT_TAGS_TO_BUILD latest git tags containing the dd suffix
+GIT_TAGS_TO_BUILD=$(git tag --sort=-creatordate --merged HEAD | grep dd | head -n $N_GIT_TAGS_TO_BUILD)
+
+while IFS= read -r GIT_TAG; do
+  # Construct the image tag
+  IMAGE_TAG="$GIT_TAG"
+  if [ "$TARGET" = "debug" ]; then
+    IMAGE_TAG="${IMAGE_TAG}-debug"
+  fi
+  if [ "$CI_PIPELINE_SOURCE" == "schedule" ]; then
+    TIMESTAMP=${CI_PIPELINE_CREATED_AT//:/-}
+    TIMESTAMP=${TIMESTAMP,,}
+    IMAGE_TAG="${IMAGE_TAG}-${TIMESTAMP}"
+  fi
+  IMAGE_REF="registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG"
+
+  # Find the right Cilium Runtime image to use for the main Cilium image build
+  if [ "$IMAGE_NAME" == "cilium" ]; then
+    CILIUM_RUNTIME_IMAGE="registry.ddbuild.io/cilium-runtime:$IMAGE_TAG"
+    BUILD_ARGS+=" --build-arg CILIUM_RUNTIME_IMAGE=$CILIUM_RUNTIME_IMAGE"
+  fi
+
+  METADATA_FILE=$(mktemp)
+  docker buildx build --platform linux/amd64,linux/arm64 \
+    --tag "$IMAGE_REF" \
+    --file "$DOCKERFILE_PATH" \
+    $BUILD_ARGS \
+    --label CILIUM_VERSION="$(cat VERSION)" \
+    --label target=prod \
+    --label CI_PIPELINE_ID="$CI_PIPELINE_ID" \
+    --label CI_JOB_ID="$CI_JOB_ID" \
+    --target "$TARGET" \
+    --push \
+    --metadata-file "$METADATA_FILE" \
+    "$DOCKER_CTX"
+
+  ddsign sign "$IMAGE_REF" --docker-metadata-file "$METADATA_FILE"
+
+  # Always build the debug version of the Cilium image
+  if [ "$IMAGE_NAME" == "cilium" ]; then
+    METADATA_FILE_DEBUG=$(mktemp)
+    docker buildx build --platform linux/amd64,linux/arm64 \
+      --tag "$IMAGE_REF"-debug \
+      --file "$DOCKERFILE_PATH" \
+      $BUILD_ARGS \
+      --label CILIUM_VERSION="$(cat VERSION)" \
+      --label target=debug \
+      --label CI_PIPELINE_ID="$CI_PIPELINE_ID" \
+      --label CI_JOB_ID="$CI_JOB_ID" \
+      --target debug \
+      --push \
+      --metadata-file "$METADATA_FILE_DEBUG" \
+      "$DOCKER_CTX"
+    ddsign sign "$IMAGE_REF"-debug --docker-metadata-file "$METADATA_FILE_DEBUG"
+  fi
+done <<< "$GIT_TAGS_TO_BUILD"


### PR DESCRIPTION
- For CI pipelines created from regular git tag pushes: no behaviour change
- For CI pipelines created from schedules on branch `v1.x-dd`: build the latest 3 git tags containing the `-dd` suffix from the branch. The docker image tags will be `$GIT_TAG-$CI_PIPELINE_CREATED_AT`, for example `1.14.12-dd1-2024-07-16t16-24-26z`
  I chose `$CI_PIPELINE_CREATED_AT` because it's human readable and it's stable for the CI pipeline, so it's easy to find the right `cilium-runtime` image tags for each `cilium` image