### PR TITLE
Do not exclude dummy devices during local addr detection

### DIFF
--- a/pkg/node/ip_linux.go
+++ b/pkg/node/ip_linux.go
@@ -23,6 +23,13 @@ func initExcludedIPs() {
 		return
 	}
 	for _, l := range links {
+		// Don't exclude dummy devices, since they may be setup by
+		// processes like nodelocaldns and they aren't always brought up. See
+		// https://github.com/kubernetes/dns/blob/fa0192f004c9571cf24d8e9868be07f57380fccb/pkg/netif/netif.go#L24-L36
+		// Such devices in down state may still be relevant.
+		if l.Type() == "dummy" {
+			continue
+		}
 		// ... also all down devices since they won't be reachable.
 		//
 		// We need to check for both "up" and "unknown" state, as some


### PR DESCRIPTION
Processes like nodelocaldns might setup a dummy device and attach a custom IP to them. But these devices aren't always brought up. If nodelocaldns IP isn't recognized as a local address, when bpf host routing is used, traffic to NLD IP would go through fib_lookup. This lookup will fail because fib_lookup doesn't work for local routes.

This is currently a blocker for enabling bpf host routing while using nodelocaldns in host network.

This is a 1.14 variant of https://github.com/cilium/cilium/pull/34228 since statedb based node address management is introduced only in 1.15 and above.