### PR TITLE
[1.15] Cherry picks for including dummy device and kvstore exp. backoff

### DIFF
--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -354,12 +354,17 @@ var whitelistDevices = []string{
 }
 
 func (n *nodeAddressController) getAddressesFromDevice(dev *Device) []NodeAddress {
-	if dev.Flags&net.FlagUp == 0 {
+	// Don't exclude addresses attached to dummy devices, since they may be setup by
+	// processes like nodelocaldns, and these devices aren't always brought up. See
+	// https://github.com/kubernetes/dns/blob/fa0192f004c9571cf24d8e9868be07f57380fccb/pkg/netif/netif.go#L24-L36
+	// Failure to include these addresses in node addresses will trigger fib_lookup
+	// when bpf host routing is enabled and result in packet drops.
+	if dev.Type != "dummy" && dev.Flags&net.FlagUp == 0 {
 		return nil
 	}
 
 	// Ignore non-whitelisted & non-selected devices.
-	if !slices.Contains(whitelistDevices, dev.Name) && !dev.Selected {
+	if !slices.Contains(whitelistDevices, dev.Name) && (!dev.Selected && dev.Type != "dummy") {
 		return nil
 	}
 
@@ -433,7 +438,7 @@ func (n *nodeAddressController) getAddressesFromDevice(dev *Device) []NodeAddres
 			})
 	}
 
-	if len(n.Config.NodePortAddresses) == 0 && dev.Name != defaults.HostDevice {
+	if len(n.Config.NodePortAddresses) == 0 && dev.Name != defaults.HostDevice && dev.Flags&net.FlagUp != 0 {
 		// Pick the NodePort addresses. Prefer private addresses if possible.
 		if ipv4PrivateIndex >= 0 {
 			addrs[ipv4PrivateIndex].NodePort = true

--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -97,6 +97,7 @@ func Connected() <-chan struct{} {
 				close(c)
 				return
 			}
+			// Client().Connected() call above has exp. backoff, this 100ms sleep is fine.
 			time.Sleep(100 * time.Millisecond)
 		}
 	}(c)

--- a/pkg/node/ip_linux.go
+++ b/pkg/node/ip_linux.go
@@ -23,6 +23,13 @@ func initExcludedIPs() {
 		return
 	}
 	for _, l := range links {
+		// Don't exclude dummy devices, since they may be setup by
+		// processes like nodelocaldns and they aren't always brought up. See
+		// https://github.com/kubernetes/dns/blob/fa0192f004c9571cf24d8e9868be07f57380fccb/pkg/netif/netif.go#L24-L36
+		// Such devices in down state may still be relevant.
+		if l.Type() == "dummy" {
+			continue
+		}
 		// ... also all down devices since they won't be reachable.
 		//
 		// We need to check for both "up" and "unknown" state, as some


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/34228 
Forward port of https://github.com/DataDog/cilium/pull/571 