### PR TITLE
Campaigner CI: Fix logic to find the main branch

### DIFF
--- a/.gitlab/run-campaign.sh
+++ b/.gitlab/run-campaign.sh
@@ -3,8 +3,8 @@ set -exuo pipefail
 
 # This is required for the set-head command to succeed
 git config --global --add safe.directory "$CI_PROJECT_DIR"
-# Set the branch where .campaigns.toml is located
-BRANCH=$(git branch --all --contains "$CI_COMMIT_TAG" --format='%(refname:short)' | sed -n 's/^origin\///p')
+# Set the branch where .campaigns.toml is located (e.g. v1.15-dd)
+BRANCH=$(sed -E 's/^/v/; s/\.[[:digit:]]+$/-dd/g' VERSION)
 git remote set-head origin "$BRANCH"
 
 export CURRENT_DATE=$(date +"%Y-%m-%d")


### PR DESCRIPTION
The logic for finding the "main" branch for a tag (ex: branch `v1.15-dd` for tag `1.15.9-dd2`) was not robust enough because multiple branches can contain the same tag. This change simply uses the `VERSION` file to derive the main branch.