### PR TITLE
Trigger Campaigner CI pipelines from a main schedule job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,9 +14,9 @@ before_script:
   image: $CI_DOCKER_IMAGE
   tags: ["arch:arm64"]
   rules:
-    # Run the pipeline for all pushed tags + schedules
+    # Run the pipeline for all pushed tags + triggered pipelines
     - if: $CI_COMMIT_TAG
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "pipeline"
   id_tokens:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
@@ -88,9 +88,18 @@ build-docker-image-clustermesh-apiserver:
       GOLANG_IMAGE=registry.ddbuild.io/images/mirror/golang:1.22.8@sha256:628529a29f130a8ab336b994be99d134ce98cd23b8f2052d8995678681e97ca2
     TARGET: release
 
+trigger-builds:
+  stage: .pre
+  image: $CI_DOCKER_IMAGE
+  tags: ["arch:arm64"]
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  script:
+    - .gitlab/trigger-builds.sh
+
 run-campaign:
   extends: .run-campaign
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "pipeline"
   script:
     - .gitlab/run-campaign.sh

--- a/.gitlab/build-image.sh
+++ b/.gitlab/build-image.sh
@@ -16,7 +16,8 @@ IMAGE_TAG="$CI_COMMIT_TAG"
 if [ "$TARGET" = "debug" ]; then
   IMAGE_TAG="${IMAGE_TAG}-debug"
 fi
-if [ "$CI_PIPELINE_SOURCE" == "schedule" ]; then
+# If the pipeline was triggered by a schedule (used for Campaigner runs), append a timestamp to the image tag
+if [ "$CI_PIPELINE_SOURCE" == "pipeline" ]; then
   TIMESTAMP=${CI_PIPELINE_CREATED_AT//:/-}
   TIMESTAMP=${TIMESTAMP,,}
   IMAGE_TAG="${IMAGE_TAG}-${TIMESTAMP}"

--- a/.gitlab/trigger-builds.sh
+++ b/.gitlab/trigger-builds.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+# Find the 3 latest -dd tags on the current branch
+GIT_TAGS_TO_BUILD=$(git --no-pager tag --sort=-creatordate --merged HEAD --list \*-dd\* | head -n 3)
+
+# Trigger a CI pipeline for each tag
+for TAG in $GIT_TAGS_TO_BUILD; do
+  curl --request POST \
+       --form token="${CI_JOB_TOKEN}" \
+       --form ref="$TAG" \
+       "https://gitlab.ddbuild.io/api/v4/projects/${CI_PROJECT_ID}/trigger/pipeline"
+  # Sleep for 20 minutes to prevent downstream Campaigner pipelines from running into merge conflicts because they update the same files
+  sleep 1200
+done


### PR DESCRIPTION
The new `trigger-builds` CI job will be scheduled on each one of our main branches (ex: `v1.15-dd`). It will find the 3 latest tags and will make an API call to Gitlab to trigger child pipelines for each tag. These pipelines will build the images and will execute the associated Campaigner runs. 