### PR TITLE
Fix Gitlab stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,7 @@
+stages:
+  - trigger
+  - build
+
 variables:
   CI_DOCKER_IMAGE: registry.ddbuild.io/images/docker:24.0.4-gbi-focal
   DOCKER_CTX: "."
@@ -87,7 +91,7 @@ build-docker-image-clustermesh-apiserver:
     TARGET: release
 
 trigger-builds:
-  stage: .pre
+  stage: trigger
   image: $CI_DOCKER_IMAGE
   tags: ["arch:arm64"]
   rules:


### PR DESCRIPTION
Follow-up to https://github.com/DataDog/cilium/pull/582

This fixes the following problem:
> If a pipeline contains only jobs in the .pre or .post stages, it does not run.

https://docs.gitlab.com/ee/ci/yaml/#stages
