### PR TITLE
[debug] Always include debug symbols in the agent debug image

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -64,7 +64,6 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
 # Extract debug symbols to /tmp/debug and strip the binaries if NOSTRIP is not set.
 RUN set -xe && \
     export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
-    mkdir -p $D && \
     cd /tmp/install/${TARGETOS}/${TARGETARCH} && \
     find . -type f \
       -executable \
@@ -72,7 +71,8 @@ RUN set -xe && \
         'filename=$(basename ${0}) && \
          objcopy --only-keep-debug ${0} ${0}.debug && \
          if ! echo "$MODIFIERS" | grep "NOSTRIP=1" ; then objcopy --strip-all ${0} && (cd $(dirname ${0}) && objcopy --add-gnu-debuglink=${filename}.debug ${filename}) ; fi && \
-         mv -v ${0}.debug ${D}/${filename}.debug' \
+         mkdir -p $(dirname ${D}/${0}) && \
+         mv -v ${0}.debug ${D}/${0}.debug' \
       {} \;
 
 COPY images/cilium/init-container.sh \
@@ -131,10 +131,9 @@ COPY --from=builder /go/bin/dlv /usr/bin/dlv
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/bin/debug-wrapper /usr/bin/cilium-agent
 
 # Copy in the debug symbols in case the binaries were stripped
-COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /usr/lib/debug
+COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH}/ /usr/lib/debug/
 
 # Ensure dlv finds the debug symbols. Due to CGO_ENABLED=0, we have no GNU build-id, so Delve's default search path
 # is insufficient.
 RUN mkdir -p ${HOME}/.config/dlv && \
-    echo 'debug-info-directories: ["/usr/lib/debug/.build-id","/usr/lib/debug"]' > ${HOME}/.config/dlv/config.yml && \
-    ln -s /usr/lib/debug/cilium-agent.debug /usr/lib/debug/cilium-agent-bin.debug
+    echo 'debug-info-directories: ["/usr/lib/debug/.build-id","/usr/lib/debug"]' > ${HOME}/.config/dlv/config.yml

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -43,10 +43,12 @@ ARG MODIFIERS
 # as that will mess with caching for incremental builds!
 #
 WORKDIR /go/src/github.com/cilium/cilium
+# We must override NOSTRIP=1 to ensure binaries include debug symbols for extraction. They will be stripped subsequently
+# in accordance with the supplied/default NOSTRIP setting. See "Extract debug symbols" below.
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg \
-    make GOARCH=${TARGETARCH} DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} PKG_BUILD=1 ${MODIFIERS} \
+    make GOARCH=${TARGETARCH} DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} PKG_BUILD=1 ${MODIFIERS} NOSTRIP=1 \
     build-container install-container-binary
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -59,6 +59,20 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
     install-bash-completion licenses-all && \
     mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
+# Extract debug symbols to /tmp/debug and strip the binaries if NOSTRIP is not set.
+RUN set -xe && \
+    export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
+    mkdir -p $D && \
+    cd /tmp/install/${TARGETOS}/${TARGETARCH} && \
+    find . -type f \
+      -executable \
+      -exec sh -c \
+        'filename=$(basename ${0}) && \
+         objcopy --only-keep-debug ${0} ${0}.debug && \
+         if ! echo "$MODIFIERS" | grep "NOSTRIP=1" ; then objcopy --strip-all ${0} && (cd $(dirname ${0}) && objcopy --add-gnu-debuglink=${filename}.debug ${filename}) ; fi && \
+         mv -v ${0}.debug ${D}/${filename}.debug' \
+      {} \;
+
 COPY images/cilium/init-container.sh \
      plugins/cilium-cni/install-plugin.sh \
      plugins/cilium-cni/cni-uninstall.sh \
@@ -113,3 +127,12 @@ ENV DEBUG_HOLD=${DEBUG_HOLD}
 COPY --from=builder /tmp/install/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-agent /usr/bin/cilium-agent-bin
 COPY --from=builder /go/bin/dlv /usr/bin/dlv
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/bin/debug-wrapper /usr/bin/cilium-agent
+
+# Copy in the debug symbols in case the binaries were stripped
+COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /usr/lib/debug
+
+# Ensure dlv finds the debug symbols. Due to CGO_ENABLED=0, we have no GNU build-id, so Delve's default search path
+# is insufficient.
+RUN mkdir -p ${HOME}/.config/dlv && \
+    echo 'debug-info-directories: ["/usr/lib/debug/.build-id","/usr/lib/debug"]' > ${HOME}/.config/dlv/config.yml && \
+    ln -s /usr/lib/debug/cilium-agent.debug /usr/lib/debug/cilium-agent-bin.debug


### PR DESCRIPTION
Backport from main to 1.15-dd as this was forgotten.

2 additional changes:
* `c4aebae895` was backported to 1.15 and removed the NOSTRIP=1 override so the build doesn't produce debug symbols. Fixes this.
* gdb doesn't know where to find debug symbols, but we can fix this by preserving the directory structure. Implements a solution for this.

```
root@845f6b8679c3:/home/cilium# readelf -S /usr/lib/debug/usr/bin/cilium-agent.debug
There are 23 section headers, starting at offset 0x2a0eb90:

Section Headers:
  [Nr] Name              Type             Address           Offset
       Size              EntSize          Flags  Link  Info  Align
  [ 0]                   NULL             0000000000000000  00000000
       0000000000000000  0000000000000000           0     0     0
  [ 1] .text             NOBITS           0000000000011000  00001000
       00000000027e19f4  0000000000000000  AX       0     0     16
  [ 2] .rodata           NOBITS           0000000002800000  00010000
       00000000012ae5c2  0000000000000000   A       0     0     32
  [ 3] .typelink         NOBITS           0000000003aae5e0  00010000
       0000000000027cfc  0000000000000000   A       0     0     32
  [ 4] .itablink         NOBITS           0000000003ad62e0  00010000
       0000000000014750  0000000000000000   A       0     0     32
  [ 5] .gosymtab         NOBITS           0000000003aeaa30  00010000
       0000000000000000  0000000000000000   A       0     0     1
  [ 6] .gopclntab        NOBITS           0000000003aeaa40  00010000
       0000000001f07e78  0000000000000000   A       0     0     32
  [ 7] .go.buildinfo     NOBITS           0000000005a00000  00010000
       0000000000002480  0000000000000000  WA       0     0     16
  [ 8] .noptrdata        NOBITS           0000000005a02480  00010000
       0000000000107df8  0000000000000000  WA       0     0     32
  [ 9] .data             NOBITS           0000000005b0a280  00010000
       000000000007d448  0000000000000000  WA       0     0     32
  [10] .bss              NOBITS           0000000005b876e0  00010000
       00000000005aeec0  0000000000000000  WA       0     0     32
  [11] .noptrbss         NOBITS           00000000061365a0  00010000
       00000000002173e0  0000000000000000  WA       0     0     32
  [12] .debug_abbrev     PROGBITS         0000000000000000  00001000
       0000000000000135  0000000000000000   C       0     0     1
  [13] .debug_line       PROGBITS         0000000000000000  00001135
       0000000000511252  0000000000000000   C       0     0     1
  [14] .debug_frame      PROGBITS         0000000000000000  00512387
       0000000000169f81  0000000000000000   C       0     0     1
  [15] .debug_gdb_s[...] PROGBITS         0000000000000000  0067c308
       000000000000002a  0000000000000000           0     0     1
  [16] .debug_info       PROGBITS         0000000000000000  0067c332
       0000000000a3d791  0000000000000000   C       0     0     1
  [17] .debug_loc        PROGBITS         0000000000000000  010b9ac3
       000000000073ec9b  0000000000000000   C       0     0     1
  [18] .debug_ranges     PROGBITS         0000000000000000  017f875e
       00000000001d9afa  0000000000000000   C       0     0     1
  [19] .note.go.buildid  NOTE             0000000000010f9c  00000f9c
       0000000000000064  0000000000000000   A       0     0     4
  [20] .symtab           SYMTAB           0000000000000000  019d2258
       00000000003efac0  0000000000000018          21   6774     8
  [21] .strtab           STRTAB           0000000000000000  01dc1d18
       0000000000c4cd83  0000000000000000           0     0     1
  [22] .shstrtab         STRTAB           0000000000000000  02a0ea9b
       00000000000000f0  0000000000000000           0     0     1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
  L (link order), O (extra OS processing required), G (group), T (TLS),
  C (compressed), x (unknown), o (OS specific), E (exclude),
  D (mbind), p (processor specific)

root@845f6b8679c3:/home/cilium# dlv exec /usr/bin/cilium-agent-bin
Type 'help' for list of commands.
(dlv)

root@845f6b8679c3:/home/cilium# gdb /usr/bin/cilium-agent-bin
...
Reading symbols from /usr/bin/cilium-agent-bin...
Reading symbols from /usr/lib/debug//usr/bin/cilium-agent.debug...
warning: Missing auto-load script at offset 0 in section .debug_gdb_scripts
of file /usr/lib/debug/usr/bin/cilium-agent.debug.
Use `info auto-load python-scripts [REGEXP]' to list them.
(gdb)
```

----------------------------------


When building stripped binaries (i.e. NOSTRIP unset) we end up with a Cilium Agent `debug` image that has no debug symbols available. So Delve for instance doesn't work properlyi (breakpoints can't be set, goroutine stacks are unavailable, etc).

With this change:

- If the build is invoked with `NOSTRIP=0`, then the `release` image has stripped binaries and the `debug` image has stripped binaries
  + debug symbol files in `/usr/lib/debug`.
- If the build is invoked with `NOSTRIP=1`, then the `release` image has non-stripped binaries and the `debug` image has non-stripped binaries + debug symbol files in `/usr/lib/debug`.

This ensures the `debug` image always has symbols available, so Delve works, regardless of the NOSTRIP setting at build.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
