### PR TITLE
Revert "clustermesh: guardrails for broken ENI/aws-chaining + clusterID combo"

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -150,11 +150,6 @@
 {{- if and (eq .Values.cluster.name "default") (ne (int .Values.cluster.id) 0) }}
   {{ fail "The cluster name is invalid: cannot use default value with cluster.id != 0" }}
 {{- end }}
-{{ if and
-    (or (and (ge (int .Values.cluster.id) 128) (le (int .Values.cluster.id) 255)) (and (ge (int .Values.cluster.id) 384) (le (int .Values.cluster.id) 511)))
-    (or .Values.eni.enabled .Values.alibabacloud.enabled (eq .Values.cni.chainingMode "aws-cni")) -}}
-  {{ fail "Cilium is currently affected by a bug that causes traffic matched by network policies to be incorrectly dropped when running in either ENI mode (both AWS and AlibabaCloud) or AWS VPC CNI chaining mode, if the cluster ID is 128-255 (and 384-511 when maxConnectedClusters=511). Please refer to https://github.com/cilium/cilium/issues/21330 for additional details." }}
-{{- end }}
 
 {{/* validate clustermesh-apiserver */}}
 {{- if .Values.clustermesh.useAPIServer }}

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -6,9 +6,7 @@ package clustermesh
 import (
 	"github.com/cilium/hive/cell"
 
-	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
-	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -16,7 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	nodemanager "github.com/cilium/cilium/pkg/node/manager"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 var Cell = cell.Module(
@@ -39,9 +36,6 @@ var Cell = cell.Module(
 	metrics.Metric(NewMetrics),
 	metrics.Metric(common.MetricsProvider(subsystem)),
 
-	cell.Invoke(func(info types.ClusterInfo, dcfg *option.DaemonConfig, cnimgr cni.CNIConfigManager) error {
-		return info.ValidateBuggyClusterID(dcfg.IPAM, cnimgr.GetChainingMode())
-	}),
 	cell.Invoke(ipsetNotifier),
 	cell.Invoke(nodeManagerNotifier),
 )

--- a/pkg/clustermesh/types/option.go
+++ b/pkg/clustermesh/types/option.go
@@ -4,14 +4,12 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/defaults"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -66,20 +64,6 @@ func (c ClusterInfo) ValidateStrict(log logrus.FieldLogger) error {
 	}
 
 	return c.validateName(log)
-}
-
-// ValidateBuggyClusterID returns an error if a buggy cluster ID (i.e., with the
-// 7th bit set) is used in combination with ENI IPAM mode or AWS CNI chaining.
-func (c ClusterInfo) ValidateBuggyClusterID(ipamMode, chainingMode string) error {
-	if (c.ID&0x80) != 0 && (ipamMode == ipamOption.IPAMENI || ipamMode == ipamOption.IPAMAlibabaCloud || chainingMode == "aws-cni") {
-		return errors.New("Cilium is currently affected by a bug that causes traffic matched " +
-			"by network policies to be incorrectly dropped when running in either ENI mode (both " +
-			"AWS and AlibabaCloud) or AWS VPC CNI chaining mode, if the cluster ID is 128-255 (and " +
-			"384-511 when max-connected-clusters=511). " +
-			"Please refer to https://github.com/cilium/cilium/issues/21330 for additional details.")
-	}
-
-	return nil
 }
 
 func (c ClusterInfo) validateName(log logrus.FieldLogger) error {

--- a/pkg/clustermesh/types/option_test.go
+++ b/pkg/clustermesh/types/option_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 )
 
 func TestClusterInfoValidate(t *testing.T) {
@@ -95,41 +93,6 @@ func TestClusterInfoValidate(t *testing.T) {
 			} else {
 				assert.NoError(t, tt.cinfo.ValidateStrict(log))
 			}
-		})
-	}
-}
-
-func TestClusterInfoValidateBuggyClusterID(t *testing.T) {
-	tests := []struct {
-		cinfo        ClusterInfo
-		ipamMode     string
-		chainingMode string
-		assert       assert.ErrorAssertionFunc
-	}{
-		{cinfo: ClusterInfo{ID: 127}, ipamMode: ipamOption.IPAMClusterPool, chainingMode: "foo", assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 128}, ipamMode: ipamOption.IPAMClusterPool, chainingMode: "foo", assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 255}, ipamMode: ipamOption.IPAMClusterPool, chainingMode: "foo", assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 256}, ipamMode: ipamOption.IPAMClusterPool, chainingMode: "foo", assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 127}, ipamMode: ipamOption.IPAMENI, assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 128}, ipamMode: ipamOption.IPAMENI, assert: assert.Error},
-		{cinfo: ClusterInfo{ID: 255}, ipamMode: ipamOption.IPAMAlibabaCloud, assert: assert.Error},
-		{cinfo: ClusterInfo{ID: 256}, ipamMode: ipamOption.IPAMAlibabaCloud, assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 127}, chainingMode: "aws-cni", assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 128}, chainingMode: "aws-cni", assert: assert.Error},
-		{cinfo: ClusterInfo{ID: 255}, chainingMode: "aws-cni", assert: assert.Error},
-		{cinfo: ClusterInfo{ID: 256}, chainingMode: "aws-cni", assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 383}, ipamMode: ipamOption.IPAMClusterPool, chainingMode: "foo", assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 384}, ipamMode: ipamOption.IPAMClusterPool, chainingMode: "foo", assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 511}, ipamMode: ipamOption.IPAMClusterPool, chainingMode: "foo", assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 383}, ipamMode: ipamOption.IPAMENI, chainingMode: "foo", assert: assert.NoError},
-		{cinfo: ClusterInfo{ID: 384}, ipamMode: ipamOption.IPAMENI, chainingMode: "foo", assert: assert.Error},
-		{cinfo: ClusterInfo{ID: 511}, ipamMode: ipamOption.IPAMAlibabaCloud, chainingMode: "foo", assert: assert.Error},
-	}
-
-	for _, tt := range tests {
-		name := fmt.Sprintf("ID: %d, IPAM: %s, Chaining: %s", tt.cinfo.ID, tt.ipamMode, tt.chainingMode)
-		t.Run(name, func(t *testing.T) {
-			tt.assert(t, tt.cinfo.ValidateBuggyClusterID(tt.ipamMode, tt.chainingMode))
 		})
 	}
 }


### PR DESCRIPTION
This reverts commit 20effcdb5b4c0b0df3f7ae2af9260d428bc18a5c.

We don't need this because we have a fix in our fork (https://github.com/DataDog/cilium/commit/f9518059cf9ed2fbbe5683c25dbb6015b6abb499)