### PR TITLE
CI: Improve matching of tags to rebuild [1.16]

### DIFF
--- a/.gitlab/trigger-builds.sh
+++ b/.gitlab/trigger-builds.sh
@@ -2,7 +2,7 @@
 set -exuo pipefail
 
 # Find the 3 latest -dd tags on the current branch
-GIT_TAGS_TO_BUILD=$(git --no-pager tag --sort=-creatordate --merged HEAD --list \*-dd\* | head -n 3)
+GIT_TAGS_TO_BUILD=$(git --no-pager tag --sort=-creatordate --merged HEAD | grep -E ".*-dd[0-9]+$" | head -n 3)
 
 # Trigger a CI pipeline for each tag
 for TAG in $GIT_TAGS_TO_BUILD; do


### PR DESCRIPTION
Only match tags looking like `1.15.10-dd2` or `1.16.4-dd1` and don't match `1.15.10-dd2-test` and similar.

1.15 PR: https://github.com/DataDog/cilium/pull/589