### PR TITLE
[1.16] Add more image build jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,19 +2,32 @@ stages:
   - trigger
   - build
 
+default:
+  tags: ["arch:amd64"]
+  image: registry.ddbuild.io/images/docker:24.0.4-gbi-focal
+
 variables:
-  CI_DOCKER_IMAGE: registry.ddbuild.io/images/docker:24.0.4-gbi-focal
   DOCKER_CTX: "."
   DOCKER_BUILD_ARGS: ""
+
+  ALPINE_IMAGE: registry.ddbuild.io/images/mirror/library/alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
+  BASE_IMAGE: registry.ddbuild.io/images/base/gbi-distroless:release
+  CILIUM_BPFTOOL_IMAGE: registry.ddbuild.io/images/mirror/cilium/cilium-bpftool:0db3a73729ceb42e947d826bb96a655be79e5317@sha256:de23c9546c4eafab33f75d6f5d129947bbbafc132dbd113c0cecc9a61929e6b0
+  CILIUM_BUILDER_IMAGE: registry.ddbuild.io/images/mirror/cilium/cilium-builder:2bc05d278f1cee9ae39bb7631ed7fbfcca4a7b08@sha256:d11406ddfaeab85d3fc1f10836768ea60b716b456b9266f3ed8070f1bd96ffc7
+  CILIUM_ENVOY_IMAGE: registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5@sha256:a69dfe0e54b24b0ff747385c8feeae0612cfbcae97bfcc8ee42a773bb3f69c88
+  CILIUM_IPTABLES_IMAGE: registry.ddbuild.io/images/mirror/cilium/iptables:67f517af50e18f64cd12625021f1c39246bb4f92@sha256:d075f03e89aacf51908346ec8ed5d251b8d3ad528ce30a710fcd074cdf91f11d
+  CILIUM_LLVM_IMAGE: registry.ddbuild.io/images/mirror/cilium/cilium-llvm:9f1bfe736009afb1fbb562718bbc42ea07d37d8e@sha256:a666a7a01a2dc610c3ab6e32f25ca5e294201f3cbbc01f233320c527955deee3
+  FIPS_BASE_IMAGE: registry.ddbuild.io/images/base/gbi-ubuntu_2204-fips:release
+  GOLANG_IMAGE: registry.ddbuild.io/images/mirror/library/golang:1.22.11@sha256:d5b17d684180648e16ea974bea677498945e8b619f7b26325958d8d99e97f9ea
+  TESTER_IMAGE: registry.ddbuild.io/images/mirror/cilium/image-tester:dd09c8d3ef349a909fbcdc99279516baef153f22@sha256:c056d064cb47c97acd607343db5457e1d49d9338d6d8a87e93e23cc93f052c73
+  UBUNTU_IMAGE: registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
 
 # Force git to remove any reference to the local disk copy of the repository
 before_script:
   - git repack -a -d && rm -f .git/objects/info/alternates
 
-.build-docker-image: &build-docker-image
+.build-docker-image:
   stage: build
-  image: $CI_DOCKER_IMAGE
-  tags: ["arch:arm64"]
   rules:
     # Run the pipeline for all pushed tags + triggered pipelines
     - if: $CI_COMMIT_TAG
@@ -22,79 +35,142 @@ before_script:
   id_tokens:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
-  script:
-    - .gitlab/build-image.sh
+  script: .gitlab/build-image.sh
 
-build-docker-image-operator:
-  <<: *build-docker-image
+cilium-operator:
+  extends: .build-docker-image
   variables:
-    IMAGE_NAME: cilium-operator
     DOCKERFILE_PATH: images/operator/Dockerfile
     DOCKER_BUILD_ARGS: |
       OPERATOR_VARIANT=operator
-      BASE_IMAGE=registry.ddbuild.io/images/base/gbi-distroless:release
-      GOLANG_IMAGE=registry.ddbuild.io/images/mirror/library/golang:1.22.11@sha256:d5b17d684180648e16ea974bea677498945e8b619f7b26325958d8d99e97f9ea
-      ALPINE_IMAGE=registry.ddbuild.io/images/mirror/library/alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
-      CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:2bc05d278f1cee9ae39bb7631ed7fbfcca4a7b08@sha256:d11406ddfaeab85d3fc1f10836768ea60b716b456b9266f3ed8070f1bd96ffc7
+      BASE_IMAGE=$BASE_IMAGE
+      GOLANG_IMAGE=$GOLANG_IMAGE
+      ALPINE_IMAGE=$ALPINE_IMAGE
+      CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
     TARGET: release
 
-build-docker-image-runtime:
-  <<: *build-docker-image
+cilium-operator-fips:
+  extends: .build-docker-image
   variables:
-    IMAGE_NAME: cilium-runtime
+    DOCKERFILE_PATH: images/operator/Dockerfile
+    DOCKER_BUILD_ARGS: |
+      OPERATOR_VARIANT=operator
+      BASE_IMAGE=$FIPS_BASE_IMAGE
+      GOLANG_IMAGE=$GOLANG_IMAGE
+      ALPINE_IMAGE=$ALPINE_IMAGE
+      CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
+    TARGET: release
+
+cilium-operator-generic:
+  extends: .build-docker-image
+  variables:
+    DOCKERFILE_PATH: images/operator/Dockerfile
+    DOCKER_BUILD_ARGS: |
+      OPERATOR_VARIANT=operator-generic
+      BASE_IMAGE=$BASE_IMAGE
+      GOLANG_IMAGE=$GOLANG_IMAGE
+      ALPINE_IMAGE=$ALPINE_IMAGE
+      CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
+    TARGET: release
+
+cilium-operator-aws:
+  extends: .build-docker-image
+  variables:
+    DOCKERFILE_PATH: images/operator/Dockerfile
+    DOCKER_BUILD_ARGS: |
+      OPERATOR_VARIANT=operator-aws
+      BASE_IMAGE=$BASE_IMAGE
+      GOLANG_IMAGE=$GOLANG_IMAGE
+      ALPINE_IMAGE=$ALPINE_IMAGE
+      CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
+    TARGET: release
+
+cilium-operator-aws-fips:
+  extends: .build-docker-image
+  variables:
+    DOCKERFILE_PATH: images/operator/Dockerfile
+    DOCKER_BUILD_ARGS: |
+      OPERATOR_VARIANT=operator-aws
+      BASE_IMAGE=$FIPS_BASE_IMAGE
+      GOLANG_IMAGE=$GOLANG_IMAGE
+      ALPINE_IMAGE=$ALPINE_IMAGE
+      CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
+    TARGET: release
+
+cilium-operator-azure:
+  extends: .build-docker-image
+  variables:
+    DOCKERFILE_PATH: images/operator/Dockerfile
+    DOCKER_BUILD_ARGS: |
+      OPERATOR_VARIANT=operator-azure
+      BASE_IMAGE=$BASE_IMAGE
+      GOLANG_IMAGE=$GOLANG_IMAGE
+      ALPINE_IMAGE=$ALPINE_IMAGE
+      CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
+    TARGET: release
+
+cilium-runtime:
+  extends: .build-docker-image
+  variables:
     DOCKERFILE_PATH: images/runtime/Dockerfile
     DOCKER_BUILD_ARGS: |
-      TESTER_IMAGE=registry.ddbuild.io/images/mirror/cilium/image-tester:dd09c8d3ef349a909fbcdc99279516baef153f22@sha256:c056d064cb47c97acd607343db5457e1d49d9338d6d8a87e93e23cc93f052c73
-      GOLANG_IMAGE=registry.ddbuild.io/images/mirror/library/golang:1.22.11@sha256:d5b17d684180648e16ea974bea677498945e8b619f7b26325958d8d99e97f9ea
-      UBUNTU_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
-      CILIUM_LLVM_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-llvm:9f1bfe736009afb1fbb562718bbc42ea07d37d8e@sha256:a666a7a01a2dc610c3ab6e32f25ca5e294201f3cbbc01f233320c527955deee3
-      CILIUM_BPFTOOL_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-bpftool:0db3a73729ceb42e947d826bb96a655be79e5317@sha256:de23c9546c4eafab33f75d6f5d129947bbbafc132dbd113c0cecc9a61929e6b0
-      CILIUM_IPTABLES_IMAGE=registry.ddbuild.io/images/mirror/cilium/iptables:67f517af50e18f64cd12625021f1c39246bb4f92@sha256:d075f03e89aacf51908346ec8ed5d251b8d3ad528ce30a710fcd074cdf91f11d
+      TESTER_IMAGE=$TESTER_IMAGE
+      GOLANG_IMAGE=$GOLANG_IMAGE
+      UBUNTU_IMAGE=$UBUNTU_IMAGE
+      CILIUM_LLVM_IMAGE=$CILIUM_LLVM_IMAGE
+      CILIUM_BPFTOOL_IMAGE=$CILIUM_BPFTOOL_IMAGE
+      CILIUM_IPTABLES_IMAGE=$CILIUM_IPTABLES_IMAGE
     DOCKER_CTX: "./images/runtime"
 
 # Caveats:
 # * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In
 #   other words, the arm64 image does not work.
-build-docker-image-cilium:
-  <<: *build-docker-image
+cilium:
+  extends: .build-docker-image
   needs:
     # The cilium image depends on the runtime image
-    - build-docker-image-runtime
+    - cilium-runtime
   variables:
-    IMAGE_NAME: cilium
     DOCKERFILE_PATH: images/cilium/Dockerfile
     DOCKER_BUILD_ARGS: |
-      CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:2bc05d278f1cee9ae39bb7631ed7fbfcca4a7b08@sha256:d11406ddfaeab85d3fc1f10836768ea60b716b456b9266f3ed8070f1bd96ffc7
-      CILIUM_ENVOY_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5@sha256:a69dfe0e54b24b0ff747385c8feeae0612cfbcae97bfcc8ee42a773bb3f69c88
+      CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
+      CILIUM_ENVOY_IMAGE=$CILIUM_ENVOY_IMAGE
     TARGET: release
     NOSTRIP: 0
 
-build-docker-image-hubble-relay:
-  <<: *build-docker-image
+hubble-relay:
+  extends: .build-docker-image
   variables:
-    IMAGE_NAME: hubble-relay
     DOCKERFILE_PATH: images/hubble-relay/Dockerfile
     DOCKER_BUILD_ARGS: |
-      BASE_IMAGE=registry.ddbuild.io/images/base/gbi-distroless:release
-      GOLANG_IMAGE=registry.ddbuild.io/images/mirror/library/golang:1.22.11@sha256:d5b17d684180648e16ea974bea677498945e8b619f7b26325958d8d99e97f9ea
-      CILIUM_BUILDER_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-builder:2bc05d278f1cee9ae39bb7631ed7fbfcca4a7b08@sha256:d11406ddfaeab85d3fc1f10836768ea60b716b456b9266f3ed8070f1bd96ffc7
+      BASE_IMAGE=$BASE_IMAGE
+      GOLANG_IMAGE=$GOLANG_IMAGE
+      CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
     TARGET: release
 
-build-docker-image-clustermesh-apiserver:
-  <<: *build-docker-image
+# This job is a duplicate of the clustermesh-apiserver one
+# We keep it until we replaced all image references from kvstoremesh to clustermesh-apiserver
+kvstoremesh:
+  extends: .build-docker-image
   variables:
-    IMAGE_NAME: kvstoremesh
     DOCKERFILE_PATH: images/clustermesh-apiserver/Dockerfile
     DOCKER_BUILD_ARGS: |
-      BASE_IMAGE=registry.ddbuild.io/images/base/gbi-distroless:release
-      GOLANG_IMAGE=registry.ddbuild.io/images/mirror/library/golang:1.22.11@sha256:d5b17d684180648e16ea974bea677498945e8b619f7b26325958d8d99e97f9ea
+      BASE_IMAGE=$BASE_IMAGE
+      GOLANG_IMAGE=$GOLANG_IMAGE
     TARGET: release
+
+cilium-clustermesh-apiserver:
+  extends: .build-docker-image
+  variables:
+    DOCKERFILE_PATH: images/clustermesh-apiserver/Dockerfile
+    DOCKER_BUILD_ARGS: |
+      BASE_IMAGE=$BASE_IMAGE
+      GOLANG_IMAGE=$GOLANG_IMAGE
+    TARGET: release
+
 
 trigger-builds:
   stage: trigger
-  image: $CI_DOCKER_IMAGE
-  tags: ["arch:arm64"]
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
-  script:
-    - .gitlab/trigger-builds.sh
+  script: .gitlab/trigger-builds.sh

--- a/.gitlab/build-image.sh
+++ b/.gitlab/build-image.sh
@@ -16,10 +16,10 @@ IMAGE_TAG="$CI_COMMIT_TAG"
 if [ "$TARGET" = "debug" ]; then
   IMAGE_TAG="${IMAGE_TAG}-debug"
 fi
-IMAGE_REF="registry.ddbuild.io/$IMAGE_NAME:$IMAGE_TAG"
+IMAGE_REF="registry.ddbuild.io/$CI_JOB_NAME:$IMAGE_TAG"
 
 # Find the right Cilium Runtime image to use for the main Cilium image build
-if [ "$IMAGE_NAME" == "cilium" ]; then
+if [ "$CI_JOB_NAME" == "cilium" ]; then
   CILIUM_RUNTIME_IMAGE="registry.ddbuild.io/cilium-runtime:$IMAGE_TAG"
   BUILD_ARGS+=" --build-arg CILIUM_RUNTIME_IMAGE=$CILIUM_RUNTIME_IMAGE"
 fi
@@ -41,7 +41,7 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 ddsign sign "$IMAGE_REF" --docker-metadata-file "$METADATA_FILE"
 
 # Always build the debug version of the Cilium Agent and Operator images
-if [[ $IMAGE_NAME == "cilium" || $IMAGE_NAME == "cilium-operator" ]]; then
+if [[ $CI_JOB_NAME == "cilium" || $CI_JOB_NAME == "cilium-operator" ]]; then
   METADATA_FILE_DEBUG=$(mktemp)
   docker buildx build --platform linux/amd64,linux/arm64 \
     --tag "$IMAGE_REF"-debug \


### PR DESCRIPTION
Couple CI updates:

First, remove the `build-docker-image-` prefix from the images build jobs so we can actually see which job builds which image instead of that: 
<img width="262" alt="image" src="https://github.com/user-attachments/assets/a8f08804-d80a-49ec-8024-29ffc53a848d" />

* Add build jobs for operator variants `generic` (gcp), `aws` and `azure` so we can start using those slimmer images in the appropriate environments
* duplicate the `kvstoremesh` image into `clustermesh-apiserver` so we can start renaming image references from the old name to the new one.
* misc gitlab-ci syntax improvements (using `extends` keywork instead of yaml anchors, using `defaults`).
* Add build jobs for a fips-based version of the operator and the aws operator

Example of the new pipeline after this PR: 
<img width="265" alt="image" src="https://github.com/user-attachments/assets/7b3f4d99-5f9b-4089-82c6-bd9fdaf52d05" />
