### PR TITLE
Switch operator back to distroless base image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,15 +9,20 @@ default:
 variables:
   DOCKER_CTX: "."
 
+  # Cilium images
   ALPINE_IMAGE: registry.ddbuild.io/images/mirror/library/alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
   CILIUM_BPFTOOL_IMAGE: registry.ddbuild.io/images/mirror/cilium/cilium-bpftool:0db3a73729ceb42e947d826bb96a655be79e5317@sha256:de23c9546c4eafab33f75d6f5d129947bbbafc132dbd113c0cecc9a61929e6b0
   CILIUM_BUILDER_IMAGE: registry.ddbuild.io/images/mirror/cilium/cilium-builder:714cfc3420a53a154dba0df63a43bc1378bebffd@sha256:13345d46c1a5b24e3b64c46ff4b334c5bbbbf784b769f1adbb8fad094f177f03
   CILIUM_ENVOY_IMAGE: registry.ddbuild.io/images/mirror/cilium/cilium-envoy:v1.31.5-1739264036-958bef243c6c66fcfd73ca319f2eb49fff1eb2ae@sha256:fc708bd36973d306412b2e50c924cd8333de67e0167802c9b48506f9d772f521
   CILIUM_IPTABLES_IMAGE: registry.ddbuild.io/images/mirror/cilium/iptables:67f517af50e18f64cd12625021f1c39246bb4f92@sha256:d075f03e89aacf51908346ec8ed5d251b8d3ad528ce30a710fcd074cdf91f11d
   CILIUM_LLVM_IMAGE: registry.ddbuild.io/images/mirror/cilium/cilium-llvm:9f1bfe736009afb1fbb562718bbc42ea07d37d8e@sha256:a666a7a01a2dc610c3ab6e32f25ca5e294201f3cbbc01f233320c527955deee3
-  FIPS_BASE_IMAGE: registry.ddbuild.io/images/base/gbi-ubuntu_2204-fips:release
   GOLANG_IMAGE: registry.ddbuild.io/images/mirror/library/golang:1.23.6@sha256:927112936d6b496ed95f55f362cc09da6e3e624ef868814c56d55bd7323e0959
   TESTER_IMAGE: registry.ddbuild.io/images/mirror/cilium/image-tester:dd09c8d3ef349a909fbcdc99279516baef153f22@sha256:c056d064cb47c97acd607343db5457e1d49d9338d6d8a87e93e23cc93f052c73
+
+  # Datadog images
+  UBUNTU_FIPS_BASE_IMAGE: registry.ddbuild.io/images/base/gbi-ubuntu_2204-fips:release
+  DISTROLESS_FIPS_BASE_IMAGE: registry.ddbuild.io/images/base/gbi-distroless-nossl-fips:release
+  DISTROLESS_ROOT_FIPS_BASE_IMAGE: registry.ddbuild.io/images/base/gbi-distroless-nossl-root-fips:release
 
 # Force git to remove any reference to the local disk copy of the repository
 before_script:
@@ -40,7 +45,7 @@ cilium-operator-generic:
     DOCKERFILE_PATH: images/operator/Dockerfile
     DOCKER_BUILD_ARGS: |
       OPERATOR_VARIANT=operator-generic
-      BASE_IMAGE=$FIPS_BASE_IMAGE
+      BASE_IMAGE=$DISTROLESS_ROOT_FIPS_BASE_IMAGE
       GOLANG_IMAGE=$GOLANG_IMAGE
       ALPINE_IMAGE=$ALPINE_IMAGE
       CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
@@ -52,7 +57,7 @@ cilium-operator-aws:
     DOCKERFILE_PATH: images/operator/Dockerfile
     DOCKER_BUILD_ARGS: |
       OPERATOR_VARIANT=operator-aws
-      BASE_IMAGE=$FIPS_BASE_IMAGE
+      BASE_IMAGE=$DISTROLESS_ROOT_FIPS_BASE_IMAGE
       GOLANG_IMAGE=$GOLANG_IMAGE
       ALPINE_IMAGE=$ALPINE_IMAGE
       CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
@@ -64,7 +69,7 @@ cilium-operator-azure:
     DOCKERFILE_PATH: images/operator/Dockerfile
     DOCKER_BUILD_ARGS: |
       OPERATOR_VARIANT=operator-azure
-      BASE_IMAGE=$FIPS_BASE_IMAGE
+      BASE_IMAGE=$DISTROLESS_ROOT_FIPS_BASE_IMAGE
       GOLANG_IMAGE=$GOLANG_IMAGE
       ALPINE_IMAGE=$ALPINE_IMAGE
       CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
@@ -77,11 +82,12 @@ cilium-runtime:
     DOCKER_BUILD_ARGS: |
       TESTER_IMAGE=$TESTER_IMAGE
       GOLANG_IMAGE=$GOLANG_IMAGE
-      UBUNTU_IMAGE=$FIPS_BASE_IMAGE
+      UBUNTU_IMAGE=$UBUNTU_FIPS_BASE_IMAGE
       CILIUM_LLVM_IMAGE=$CILIUM_LLVM_IMAGE
       CILIUM_BPFTOOL_IMAGE=$CILIUM_BPFTOOL_IMAGE
       CILIUM_IPTABLES_IMAGE=$CILIUM_IPTABLES_IMAGE
     DOCKER_CTX: "./images/runtime"
+    TARGET: rootfs
 
 # Caveats:
 # * The build image is single-arch amd64 and we're doing cross-compilation, so the dlv copy is only valid on amd64. In
@@ -104,7 +110,7 @@ hubble-relay:
   variables:
     DOCKERFILE_PATH: images/hubble-relay/Dockerfile
     DOCKER_BUILD_ARGS: |
-      BASE_IMAGE=$FIPS_BASE_IMAGE
+      BASE_IMAGE=$UBUNTU_FIPS_BASE_IMAGE
       GOLANG_IMAGE=$GOLANG_IMAGE
       CILIUM_BUILDER_IMAGE=$CILIUM_BUILDER_IMAGE
     TARGET: release
@@ -114,7 +120,7 @@ cilium-clustermesh-apiserver:
   variables:
     DOCKERFILE_PATH: images/clustermesh-apiserver/Dockerfile
     DOCKER_BUILD_ARGS: |
-      BASE_IMAGE=$FIPS_BASE_IMAGE
+      BASE_IMAGE=$DISTROLESS_FIPS_BASE_IMAGE
       GOLANG_IMAGE=$GOLANG_IMAGE
     TARGET: release
 

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -76,9 +76,6 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
 
 FROM ${BASE_IMAGE} AS release
 
-# Datadog Modification: operator has to run as root
-USER root
-
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.

--- a/images/runtime/Dockerfile
+++ b/images/runtime/Dockerfile
@@ -63,5 +63,6 @@ COPY --from=bpftool-dist /test /test
 RUN /test/bin/cst -C /test/llvm
 RUN /test/bin/cst -C /test/bpftool
 
-# Datadog modification: do not squash the layers to not lose GBI labels
-FROM rootfs
+FROM scratch
+LABEL maintainer="maintainer@cilium.io"
+COPY --from=rootfs / /


### PR DESCRIPTION
When we migrated all cilium images to a FIPS base in #600 we had to use a full ubuntu base image everywhere because we didn't have a FIPS distroless base image. This means that the operator and clustermesh images moved from a distroless base to an ubuntu base in order to have a FIPS base.
Now that we have FIPS distroless images, we can move the operator and clustermesh images back to a distroless base without loosing any FIPSiness.

Additional goodies:
* We have a `root` variant of the distroless fips image, meaning we can drop a `USER root` modification from the operator Dockerfile (see https://github.com/DataDog/cilium/commit/bfee99cd3f6c64a2cb0eda394b2feefa464b8aca)
* Similarly, we can set the `TARGET` argument of the `cilium-runtime` image build job to drop a a [datadog patch](https://github.com/DataDog/cilium/commit/bfee99cd3f6c64a2cb0eda394b2feefa464b8aca#diff-e05830e1064c11185b763312fc9c003085c0e995780b7f94fe37caced924a307L63-L65) from that dockerfile
* The last manual Dockerfile modification from bfee99cd3f6c64a2cb0eda394b2feefa464b8aca is the `USER root` line in the runtime image dockerfile, we can get rid of it when we have a root variant of the ubuntu FIPS GBI image (asked about it [here](https://dd.slack.com/archives/C05UJQPRUN5/p1741264045737479))

I tested that the cilium-runtime built with target `rootfs` properly preserves the labels of its underlying base image:
```sh
$ docker inspect registry.ddbuild.io/cilium-runtime:1.16.7-dd2-fips-3 | jq '.[].Config.Labels'
{
  "CILIUM_VERSION": "1.16.7",
  "CI_JOB_ID": "XXX",
  "CI_PIPELINE_ID": "XXX",
  "base_image_target": "prod",
  "baseimage.arch": "arm64",
  "baseimage.aws_uses_fips_endpoint_override": "yes",
  "baseimage.buildstamp": "2025-03-04T15:53:04Z",
  "baseimage.is_fedramp_high_compliant": "yes",
  "baseimage.isgbi": "yes",
  "baseimage.name": "images/base/gbi-ubuntu_2204-fips",
  "baseimage.os": "ubuntu jammy LTS FIPS",
  "org.opencontainers.image.ref.name": "ubuntu",
  "org.opencontainers.image.version": "22.04",
  "target": "prod"
}
```