### PR TITLE
Backport "watchers: disable CRD to kvstore handover logic" to 1.16

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -521,6 +521,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Duration(option.KVstoreConnectivityTimeout, defaults.KVstoreConnectivityTimeout, "Time after which an incomplete kvstore operation  is considered failed")
 	option.BindEnv(vp, option.KVstoreConnectivityTimeout)
 
+	flags.Bool(option.KVstorePodNetworkSupport, defaults.KVstorePodNetworkSupport, "Enable the support for running the Cilium KVstore in pod network")
+	flags.MarkHidden(option.KVstorePodNetworkSupport)
+	option.BindEnv(vp, option.KVstorePodNetworkSupport)
+
 	flags.Var(option.NewNamedMapOptions(option.KVStoreOpt, &option.Config.KVStoreOpt, nil),
 		option.KVStoreOpt, "Key-value store options e.g. etcd.address=127.0.0.1:4001")
 	option.BindEnv(vp, option.KVStoreOpt)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -340,6 +340,10 @@ const (
 	// a kvstore path for too long.
 	KVStoreStaleLockTimeout = 30 * time.Second
 
+	// KVstorePodNetworkSupport represents whether to enable the support for
+	// running the Cilium KVstore in pod network.
+	KVstorePodNetworkSupport = false
+
 	// PolicyQueueSize is the default queue size for policy-related events.
 	PolicyQueueSize = 100
 

--- a/pkg/endpointcleanup/cleanup.go
+++ b/pkg/endpointcleanup/cleanup.go
@@ -63,7 +63,18 @@ type cleanup struct {
 }
 
 func registerCleanup(p params) {
-	if !p.Clientset.IsEnabled() || !p.Cfg.EnableStaleCiliumEndpointCleanup || p.DaemonCfg.DisableCiliumEndpointCRD {
+	if !p.Clientset.IsEnabled() || !p.Cfg.EnableStaleCiliumEndpointCleanup || p.DaemonCfg.DisableCiliumEndpointCRD ||
+		// When Cilium is configured in KVstore mode, and support for running the kvstore
+		// in pod network is disabled, we don't start the CiliumEndpoints informer at all.
+		// Hence, let's disable this GC logic as well, given that it would otherwise need
+		// to start it to populate the store content. Indeed, no one is expected to be
+		// watching them, and we can accept the possibility that we leak a few objects in
+		// very specific and rare circumstances [1], until the corresponding pod gets deleted.
+		// The respective kvstore entries, which are not taken into account here, will be
+		// instead eventually deleted when the corresponding lease expires.
+		//
+		// [1]: cilium/cilium#20350
+		p.DaemonCfg.KVstoreEnabledWithoutPodNetworkSupport() {
 		p.Logger.Info("Init procedure to clean up stale CiliumEndpoint disabled")
 		return
 	}

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -261,11 +261,13 @@ func (k *K8sPodWatcher) podsInit(asyncControllers *sync.WaitGroup) {
 		return cancel
 	}
 
-	// We will watch for pods on th entire cluster to keep existing
+	// We will watch for pods on the entire cluster to keep existing
 	// functionality untouched. If we are running with CiliumEndpoint CRD
 	// enabled then it means that we can simply watch for pods that are created
-	// for this node.
-	if !option.Config.DisableCiliumEndpointCRD {
+	// for this node. Similarly, we don't need to watch for all pods when the
+	// support for running the Cilium KVstore in pod network is disabled, as in
+	// that case we just rely on the KVStore data from the beginning.
+	if !option.Config.DisableCiliumEndpointCRD || option.Config.KVstoreEnabledWithoutPodNetworkSupport() {
 		watchNodePods()
 		return
 	}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -322,6 +322,12 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context, cachesSynced chan str
 type WatcherConfiguration interface {
 	// K8sNetworkPolicyEnabled returns true if cilium agent needs to support K8s NetworkPolicy
 	K8sNetworkPolicyEnabled() bool
+
+	// KVstoreEnabledWithoutPodNetworkSupport returns whether Cilium is configured to connect
+	// to an external KVStore, and the support for running it in pod network is disabled.
+	// In this case, we don't need to start the CiliumNode and CiliumEndpoint watchers at
+	// all, given that the CRD to kvstore handover logic is not required.
+	KVstoreEnabledWithoutPodNetworkSupport() bool
 }
 
 // enableK8sWatchers starts watchers for given resources.
@@ -341,14 +347,18 @@ func (k *K8sWatcher) enableK8sWatchers(ctx context.Context, resourceNames []stri
 		case k8sAPIGroupNamespaceV1Core:
 			k.k8sNamespaceWatcher.namespacesInit()
 		case k8sAPIGroupCiliumNodeV2:
-			asyncControllers.Add(1)
-			go k.k8sCiliumNodeWatcher.ciliumNodeInit(ctx, asyncControllers)
+			if !k.cfg.KVstoreEnabledWithoutPodNetworkSupport() {
+				asyncControllers.Add(1)
+				go k.k8sCiliumNodeWatcher.ciliumNodeInit(ctx, asyncControllers)
+			}
 		case resources.K8sAPIGroupServiceV1Core:
 			k.k8sServiceWatcher.servicesInit()
 		case resources.K8sAPIGroupEndpointSliceOrEndpoint:
 			k.k8sEndpointsWatcher.endpointsInit()
 		case k8sAPIGroupCiliumEndpointV2:
-			k.k8sCiliumEndpointsWatcher.initCiliumEndpointOrSlices(ctx, asyncControllers)
+			if !k.cfg.KVstoreEnabledWithoutPodNetworkSupport() {
+				k.k8sCiliumEndpointsWatcher.initCiliumEndpointOrSlices(ctx, asyncControllers)
+			}
 		case k8sAPIGroupCiliumEndpointSliceV2Alpha1:
 			// no-op; handled in k8sAPIGroupCiliumEndpointV2
 		case k8sAPIGroupCiliumLocalRedirectPolicyV2:

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -19,6 +19,10 @@ func (f *fakeK8sWatcherConfiguration) K8sNetworkPolicyEnabled() bool {
 	return true
 }
 
+func (f *fakeK8sWatcherConfiguration) KVstoreEnabledWithoutPodNetworkSupport() bool {
+	return false
+}
+
 func Test_No_Resources_InitK8sSubsystem(t *testing.T) {
 	fakeClientSet, _ := client.NewFakeClientset()
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -801,6 +801,10 @@ const (
 	// KVstoreConnectivityTimeout is the timeout when performing kvstore operations
 	KVstoreConnectivityTimeout = "kvstore-connectivity-timeout"
 
+	// KVstorePodNetworkSupport enables the support for running the Cilium KVstore
+	// in pod network.
+	KVstorePodNetworkSupport = "kvstore-pod-network-support"
+
 	// IdentityChangeGracePeriod is the name of the
 	// IdentityChangeGracePeriod option
 	IdentityChangeGracePeriod = "identity-change-grace-period"
@@ -1874,6 +1878,10 @@ type DaemonConfig struct {
 	// KVstoreConnectivityTimeout is the timeout when performing kvstore operations
 	KVstoreConnectivityTimeout time.Duration
 
+	// KVstorePodNetworkSupport enables the support for running the Cilium KVstore
+	// in pod network.
+	KVstorePodNetworkSupport bool
+
 	// IdentityChangeGracePeriod is the grace period that needs to pass
 	// before an endpoint that has changed its identity will start using
 	// that new identity. During the grace period, the new identity has
@@ -2461,6 +2469,7 @@ var (
 		ToFQDNsMaxIPsPerHost:            defaults.ToFQDNsMaxIPsPerHost,
 		KVstorePeriodicSync:             defaults.KVstorePeriodicSync,
 		KVstoreConnectivityTimeout:      defaults.KVstoreConnectivityTimeout,
+		KVstorePodNetworkSupport:        defaults.KVstorePodNetworkSupport,
 		IdentityChangeGracePeriod:       defaults.IdentityChangeGracePeriod,
 		IdentityRestoreGracePeriod:      defaults.IdentityRestoreGracePeriodK8s,
 		FixedIdentityMapping:            make(map[string]string),
@@ -2761,6 +2770,12 @@ func (c *DaemonConfig) DirectRoutingDeviceRequired() bool {
 func (c *DaemonConfig) LoadBalancerUsesDSR() bool {
 	return c.NodePortMode == NodePortModeDSR ||
 		c.NodePortMode == NodePortModeHybrid
+}
+
+// KVstoreEnabledWithoutPodNetworkSupport returns whether Cilium is configured to connect
+// to an external KVStore, and the support for running it in pod network is disabled.
+func (c *DaemonConfig) KVstoreEnabledWithoutPodNetworkSupport() bool {
+	return c.KVStore != "" && !c.KVstorePodNetworkSupport
 }
 
 func (c *DaemonConfig) validateIPv6ClusterAllocCIDR() error {
@@ -3099,6 +3114,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.KVstoreKeepAliveInterval = c.KVstoreLeaseTTL / defaults.KVstoreKeepAliveIntervalFactor
 	c.KVstorePeriodicSync = vp.GetDuration(KVstorePeriodicSync)
 	c.KVstoreConnectivityTimeout = vp.GetDuration(KVstoreConnectivityTimeout)
+	c.KVstorePodNetworkSupport = vp.GetBool(KVstorePodNetworkSupport)
 	c.KVstoreMaxConsecutiveQuorumErrors = vp.GetUint(KVstoreMaxConsecutiveQuorumErrorsName)
 	c.LabelPrefixFile = vp.GetString(LabelPrefixFile)
 	c.Labels = vp.GetStringSlice(Labels)


### PR DESCRIPTION
Upstream PR https://github.com/cilium/cilium/pull/35741