### PR TITLE
[build] Use zstd compression

### DIFF
--- a/.gitlab/build-image.sh
+++ b/.gitlab/build-image.sh
@@ -49,7 +49,6 @@ docker buildx build --platform linux/amd64,linux/arm64 \
     --label CI_JOB_ID="$CI_JOB_ID" \
     --label is_fips=true \
     --target "$TARGET" \
-    --push \
     --metadata-file "$METADATA_FILE" \
     --output type=image,push=true,compression=zstd,force-compression=true \
     "$DOCKER_CTX"

--- a/.gitlab/build-image.sh
+++ b/.gitlab/build-image.sh
@@ -51,6 +51,7 @@ docker buildx build --platform linux/amd64,linux/arm64 \
     --target "$TARGET" \
     --push \
     --metadata-file "$METADATA_FILE" \
+    --output type=image,push=true,compression=zstd,force-compression=true \
     "$DOCKER_CTX"
 
 ddsign sign "$IMAGE_REF" --docker-metadata-file "$METADATA_FILE"
@@ -70,6 +71,7 @@ if [[ $IMAGE_NAME == "cilium" || $IMAGE_NAME =~ "cilium-operator" ]]; then
         --target debug \
         --push \
         --metadata-file "$METADATA_FILE_DEBUG" \
+        --output type=image,push=true,compression=zstd,force-compression=true \
         "$DOCKER_CTX"
     ddsign sign "$IMAGE_REF"-debug --docker-metadata-file "$METADATA_FILE_DEBUG"
 fi


### PR DESCRIPTION
Use zstd compression for image builds.

Force-compression ensures we recompress layers from the ground up if necessary. https://docs.docker.com/build/exporters/#compression
