### PR TITLE
v1.16-dd : Allow prefix delegation on all hypervisor types except xen

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -750,8 +750,8 @@ func (n *Node) IsPrefixDelegated() bool {
 	if !limitsAvailable {
 		return false
 	}
-	// Allocating prefixes is supported only on nitro instances
-	if limits.HypervisorType != "nitro" {
+	// Allocating prefixes is not supported on xen instances
+	if limits.HypervisorType == "xen" {
 		return false
 	}
 	// Check if this node is allowed to use prefix delegation


### PR DESCRIPTION
# What does this do

This PR aims to add the possibility of prefix delegation on AWS nodes of type `metal`. The original idea was to allow this feature only on nodes of type `nitro` [upstream PR #18463](https://github.com/cilium/cilium/pull/18463). However, this also works on nodes of type metal (which technically use nitro). The only node type that doesn't support this feature is `xen`.

# How was it tested

It was tested on a staging cluster using `metal` node groups. The allocation of IP prefixes was successful.
