### PR TITLE
Revert zstd build due to incompatibility with containerd 1.7

### DIFF
--- a/.gitlab/build-image.sh
+++ b/.gitlab/build-image.sh
@@ -49,8 +49,8 @@ docker buildx build --platform linux/amd64,linux/arm64 \
     --label CI_JOB_ID="$CI_JOB_ID" \
     --label is_fips=true \
     --target "$TARGET" \
+    --push \
     --metadata-file "$METADATA_FILE" \
-    --output type=image,push=true,compression=zstd,force-compression=true \
     "$DOCKER_CTX"
 
 ddsign sign "$IMAGE_REF" --docker-metadata-file "$METADATA_FILE"
@@ -70,7 +70,6 @@ if [[ $IMAGE_NAME == "cilium" || $IMAGE_NAME =~ "cilium-operator" ]]; then
         --target debug \
         --push \
         --metadata-file "$METADATA_FILE_DEBUG" \
-        --output type=image,push=true,compression=zstd,force-compression=true \
         "$DOCKER_CTX"
     ddsign sign "$IMAGE_REF"-debug --docker-metadata-file "$METADATA_FILE_DEBUG"
 fi


### PR DESCRIPTION
buildx is producing `application/vnd.docker.image.rootfs.diff.tar.zstd` layers which are incompatible with containerd 1.7 as it is lacking https://github.com/containerd/containerd/pull/9859.

Revert while we look for a solution.

CMPT-3383