### PR TITLE
Build zstd-compressed images with OCI media types

### DIFF
--- a/.gitlab/build-image.sh
+++ b/.gitlab/build-image.sh
@@ -50,7 +50,7 @@ docker buildx build --platform linux/amd64,linux/arm64 \
     --label is_fips=true \
     --target "$TARGET" \
     --metadata-file "$METADATA_FILE" \
-    --output type=image,push=true,compression=zstd,force-compression=true \
+    --output type=image,push=true,compression=zstd,force-compression=true,oci-mediatypes=true \
     "$DOCKER_CTX"
 
 ddsign sign "$IMAGE_REF" --docker-metadata-file "$METADATA_FILE"
@@ -69,7 +69,7 @@ if [[ $IMAGE_NAME == "cilium" || $IMAGE_NAME =~ "cilium-operator" ]]; then
         --label is_fips=true \
         --target debug \
         --metadata-file "$METADATA_FILE_DEBUG" \
-        --output type=image,push=true,compression=zstd,force-compression=true \
+        --output type=image,push=true,compression=zstd,force-compression=true,oci-mediatypes=true \
         "$DOCKER_CTX"
     ddsign sign "$IMAGE_REF"-debug --docker-metadata-file "$METADATA_FILE_DEBUG"
 fi

--- a/.gitlab/build-image.sh
+++ b/.gitlab/build-image.sh
@@ -49,8 +49,8 @@ docker buildx build --platform linux/amd64,linux/arm64 \
     --label CI_JOB_ID="$CI_JOB_ID" \
     --label is_fips=true \
     --target "$TARGET" \
-    --push \
     --metadata-file "$METADATA_FILE" \
+    --output type=image,push=true,compression=zstd,force-compression=true \
     "$DOCKER_CTX"
 
 ddsign sign "$IMAGE_REF" --docker-metadata-file "$METADATA_FILE"
@@ -70,6 +70,7 @@ if [[ $IMAGE_NAME == "cilium" || $IMAGE_NAME =~ "cilium-operator" ]]; then
         --target debug \
         --push \
         --metadata-file "$METADATA_FILE_DEBUG" \
+        --output type=image,push=true,compression=zstd,force-compression=true \
         "$DOCKER_CTX"
     ddsign sign "$IMAGE_REF"-debug --docker-metadata-file "$METADATA_FILE_DEBUG"
 fi

--- a/.gitlab/build-image.sh
+++ b/.gitlab/build-image.sh
@@ -68,7 +68,6 @@ if [[ $IMAGE_NAME == "cilium" || $IMAGE_NAME =~ "cilium-operator" ]]; then
         --label CI_JOB_ID="$CI_JOB_ID" \
         --label is_fips=true \
         --target debug \
-        --push \
         --metadata-file "$METADATA_FILE_DEBUG" \
         --output type=image,push=true,compression=zstd,force-compression=true \
         "$DOCKER_CTX"


### PR DESCRIPTION
This produces

```
 $  crane manifest registry.ddbuild.io/cilium-runtime:1.17.4-dd4-zstd1@sha256:b7ab25a6bc2d504aca08546ad2cd6e8f4bf313f01224ee1ad73fec85f3d6c4fa | grep mediaType | grep zstd | uniq
      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
```

instead of 

```
$  crane manifest registry.ddbuild.io/cilium-runtime:1.17.4-dd3@sha256:f0ebfb0783aca01336a90f6c22fdfd877d8d8a6c4486132a8d320d9f2d597c47 | grep mediaType | grep zstd | uniq
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.zstd",
```

in the previous zstd attempt, or

```
$  crane manifest registry.ddbuild.io/cilium-runtime:1.17.4-dd2@sha256:2b67507e7f1f2becd88b847129fb5f81d01c9569738c2d2c24e2a4cdb4974cd3 | grep mediaType | grep gzip | uniq
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
```

per default gzip.
