### PR TITLE
operator: add flag to control AWS API pagination

### DIFF
--- a/operator/cmd/provider_aws_flags.go
+++ b/operator/cmd/provider_aws_flags.go
@@ -63,5 +63,8 @@ func (hook *awsFlagsHooks) RegisterProviderFlag(cmd *cobra.Command, vp *viper.Vi
 	flags.String(operatorOption.EC2APIEndpoint, "", "AWS API endpoint for the EC2 service")
 	option.BindEnv(vp, operatorOption.EC2APIEndpoint)
 
+	flags.Bool(operatorOption.AWSPaginationEnabled, false, "Enable pagination for AWS EC2 API requests. The default page size is 1000 items.")
+	option.BindEnv(vp, operatorOption.AWSPaginationEnabled)
+
 	vp.BindPFlags(flags)
 }

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -217,6 +217,9 @@ const (
 	// PodRestartSelector specify the labels contained in the pod that needs to be restarted before the node can be de-stained
 	// default values: k8s-app=kube-dns
 	PodRestartSelector = "pod-restart-selector"
+
+	// AWSPaginationEnabled toggles pagination for AWS EC2 API requests. If false, MaxResults will not be set and the API will return all results in a single call (if supported).
+	AWSPaginationEnabled = "aws-pagination-enabled"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -402,6 +405,9 @@ type OperatorConfig struct {
 
 	// PodRestartSelector specify the labels contained in the pod that needs to be restarted before the node can be de-stained
 	PodRestartSelector string
+
+	// AWSPaginationEnabled toggles pagination for AWS EC2 API requests. If false, MaxResults will not be set and the API will return all results in a single call (if supported).
+	AWSPaginationEnabled bool
 }
 
 // Populate sets all options with the values from viper.
@@ -460,6 +466,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.EC2APIEndpoint = vp.GetString(EC2APIEndpoint)
 	c.ExcessIPReleaseDelay = vp.GetInt(ExcessIPReleaseDelay)
 	c.ENIGarbageCollectionInterval = vp.GetDuration(ENIGarbageCollectionInterval)
+	c.AWSPaginationEnabled = vp.GetBool(AWSPaginationEnabled)
 
 	// Azure options
 


### PR DESCRIPTION
The upstream PR 39543 is still stuck because we are waiting for a response from AWS.
In the meantime, this is a backport of this PR to our 1.17 fork with pagination disabled by default. 