### PR TITLE
Update `hubble-relay` image to use a distroless base

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,6 @@ variables:
   DOCKER_CTX: "."
 
   # Base images
-  UBUNTU_FIPS_BASE_IMAGE: registry.ddbuild.io/images/base/gbi-ubuntu_2404-fips:release
   UBUNTU_ROOT_FIPS_BASE_IMAGE: registry.ddbuild.io/images/gbi-ubuntu_2404-root-fips:release
   DISTROLESS_FIPS_BASE_IMAGE: registry.ddbuild.io/images/base/gbi-distroless-nossl-fips:release
   DISTROLESS_ROOT_FIPS_BASE_IMAGE: registry.ddbuild.io/images/base/gbi-distroless-nossl-root-fips:release
@@ -105,7 +104,7 @@ hubble-relay:
   variables:
     DOCKERFILE_PATH: images/hubble-relay/Dockerfile
     DOCKER_BUILD_ARGS: |
-      BASE_IMAGE=$UBUNTU_FIPS_BASE_IMAGE
+      BASE_IMAGE=$DISTROLESS_FIPS_BASE_IMAGE
     IMAGES_TO_MIRROR: |
       CILIUM_BUILDER_IMAGE
       GOLANG_IMAGE


### PR DESCRIPTION
Upstream `hubble-relay` image already uses a distroless base: [ref](https://github.com/cilium/cilium/blob/v1.17/images/hubble-relay/Dockerfile#L6)

Before:
```
│ Image Details ├───────────────────────────────────────
Image name: registry.ddbuild.io/hubble-relay:1.17.4-dd6
Total Image size: 264 MB
```
After:
```
│ Image Details ├───────────────────────────────────────
Image name: registry.ddbuild.io/hubble-relay:1.17.4-dd6-distroless-hubble-relay-1
Total Image size: 127 MB
```
