### PR TITLE
Fix arg parsing

### DIFF
--- a/.gitlab/build-image.sh
+++ b/.gitlab/build-image.sh
@@ -12,7 +12,7 @@ for arg_name in ${IMAGES_TO_MIRROR:-}; do
         echo "Mirroring $source_image_ref to $dest_image_ref"
         crane copy $source_image_ref $dest_image_ref
     fi
-    DOCKER_BUILD_ARGS+="\n${arg_name}=${dest_image_ref}"
+    DOCKER_BUILD_ARGS+=$'\n'"${arg_name}=${dest_image_ref}"
 done
 IFS=$' '
 


### PR DESCRIPTION
Before:
```
docker buildx build --platform linux/amd64,linux/arm64 [...] --build-arg MODIFIERS=BORINGCRYPTO=1 --build-arg UBUNTU_IMAGE=registry.ddbuild.io/images/gbi-ubuntu_2404-root-fips:release --build-arg '\nCILIUM_BPFTOOL_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-bpftool:5a9c4852a21287686009bfe1cdc1fed6e7aabdea@sha256:188e398ee30456373530698d0d29de66dda0c4428068ea430027ceb7e9c15b7c\nCILIUM_IPTABLES_IMAGE=registry.ddbuild.io/images/mirror/cilium/iptables:1331e9b1b03f70c9d8b08626d9a7126963f86478@sha256:d761d967243aced2729adde1e332a9c9def6baeb61f5f6cde5758b04e9a79355\nCILIUM_LLVM_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-llvm:1732033893-de666b6@sha256:ee005bd47b20f78a727c06fdf2275861848be7acd242603c82f86ca8faaeda90\nGOLANG_IMAGE=registry.ddbuild.io/images/mirror/library/golang:1.24.3@sha256:39d9e7d9c5d9c9e4baf0d8fff579f06d5032c0f4425cdec9e86732e8e4e374dc\nTESTER_IMAGE=registry.ddbuild.io/images/mirror/cilium/image-tester:0a7ee27812441d95926aec83929d97e93ce96aae@sha256:e96542b4f71dbc9cbe77feaf5b1fa9bd5e13122ee6418094731212f1c5667c67'
```

After:
```
docker buildx build --platform linux/amd64,linux/arm64 [...] --build-arg MODIFIERS=BORINGCRYPTO=1 --build-arg UBUNTU_IMAGE=registry.ddbuild.io/images/gbi-ubuntu_2404-root-fips:release --build-arg CILIUM_BPFTOOL_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-bpftool:5a9c4852a21287686009bfe1cdc1fed6e7aabdea@sha256:188e398ee30456373530698d0d29de66dda0c4428068ea430027ceb7e9c15b7c --build-arg CILIUM_IPTABLES_IMAGE=registry.ddbuild.io/images/mirror/cilium/iptables:1331e9b1b03f70c9d8b08626d9a7126963f86478@sha256:d761d967243aced2729adde1e332a9c9def6baeb61f5f6cde5758b04e9a79355 --build-arg CILIUM_LLVM_IMAGE=registry.ddbuild.io/images/mirror/cilium/cilium-llvm:1732033893-de666b6@sha256:ee005bd47b20f78a727c06fdf2275861848be7acd242603c82f86ca8faaeda90 --build-arg GOLANG_IMAGE=registry.ddbuild.io/images/mirror/library/golang:1.24.3@sha256:39d9e7d9c5d9c9e4baf0d8fff579f06d5032c0f4425cdec9e86732e8e4e374dc --build-arg TESTER_IMAGE=registry.ddbuild.io/images/mirror/cilium/image-tester:0a7ee27812441d95926aec83929d97e93ce96aae@sha256:e96542b4f71dbc9cbe77feaf5b1fa9bd5e13122ee6418094731212f1c5667c67
```