### PR TITLE
[1.17] aws client: remove internal rate-limiting

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
@@ -108,6 +110,12 @@ func NewConfig(ctx context.Context) (aws.Config, error) {
 
 	cfg.Region = instance.Region
 	cfg.EndpointResolver = aws.EndpointResolverFunc(endpoints.Resolver)
+	cfg.Retryer = func() aws.Retryer {
+		return retry.NewStandard(func(o *retry.StandardOptions) {
+			// We only want to rely on internal Cilium rate-limiting
+			o.RateLimiter = ratelimit.None
+		})
+	}
 
 	return cfg, nil
 }


### PR DESCRIPTION
Backport https://github.com/cilium/cilium/pull/38550 to our fork