### PR TITLE
Add job to build a nydus version of the `cilium` image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -232,6 +232,13 @@ cilium:
       CILIUM_BUILDER_IMAGE
       CILIUM_ENVOY_IMAGE
 
+cilium-nydus:
+  extends: .build-docker-image
+  needs:
+    - cilium
+  image: registry.ddbuild.io/images/nydus:v75056644-ec4645e-v2.3.5@sha256:9213478316ac036c0f6bb6a014c39a5a7c95c5ba57e51d7f17948505e3a4ed09
+  script: nydus-convert registry.ddbuild.io/cilium:${CI_COMMIT_TAG} registry.ddbuild.io/cilium:${CI_COMMIT_TAG}-nydus
+
 hubble-relay:
   extends: .build-docker-image
   variables:


### PR DESCRIPTION
Add job to build a nydus version of the `cilium` image