### PR TITLE
[1.18] Backport: return ICMP "Destination unreachable" on ipv4 egress policy denials

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -27,6 +27,7 @@
 #include "lib/ipv6.h"
 #include "lib/ipv4.h"
 #include "lib/icmp6.h"
+#include "lib/icmp.h"
 #include "lib/eth.h"
 #include "lib/dbg.h"
 #include "lib/l3.h"
@@ -1010,8 +1011,18 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 						   auth_type);
 		}
 
-		if (verdict != CTX_ACT_OK)
+		if (verdict != CTX_ACT_OK) {
+			/* If policy_deny_response_enabled is set and the packet has been denied,
+			 * respond with an ICMPv4 "Destination Unreachable"
+			 */
+			if (CONFIG(policy_deny_response_enabled) &&
+			    (verdict == DROP_POLICY || verdict == DROP_POLICY_DENY)) {
+				ctx_store_meta(ctx, CB_VERDICT, verdict);
+				return tail_call_internal(ctx, CILIUM_CALL_IPV4_POLICY_DENIED,
+							ext_err);
+			}
 			return verdict;
+		}
 
 		break;
 	case CT_RELATED:
@@ -2435,5 +2446,27 @@ out:
 
 	return ret;
 }
+
+#ifdef ENABLE_IPV4
+__declare_tail(CILIUM_CALL_IPV4_POLICY_DENIED)
+int tail_policy_denied_ipv4(struct __ctx_buff *ctx)
+{
+	int ret;
+	__u32 verdict = ctx_load_meta(ctx, CB_VERDICT);
+
+	ret = generate_icmp4_reply(ctx, ICMP_DEST_UNREACH, ICMP_PKT_FILTERED);
+	if (!ret) {
+		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, ctx_get_ifindex(ctx));
+		ret = redirect_self(ctx);
+
+		if (!IS_ERR(ret)) {
+			update_metrics(ctx_full_len(ctx), METRIC_EGRESS, __DROP_REASON(verdict));
+			return ret;
+		}
+	}
+
+	return send_drop_notify_error(ctx, SECLABEL_IPV4, ret, METRIC_EGRESS);
+}
+#endif /* ENABLE_IPV4 */
 
 BPF_LICENSE("Dual BSD/GPL");

--- a/bpf/include/bpf/config/node.h
+++ b/bpf/include/bpf/config/node.h
@@ -22,3 +22,5 @@ NODE_CONFIG(__u32, trace_payload_len, "Length of payload to capture when tracing
 #define TRACE_PAYLOAD_LEN CONFIG(trace_payload_len) /* Backwards compatibility */
 
 NODE_CONFIG(__u32, trace_payload_len_overlay, "Length of payload to capture when tracing overlay packets.")
+
+NODE_CONFIG(bool, policy_deny_response_enabled, "Enable ICMP responses for policy-denied traffic")

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -663,6 +663,7 @@ enum {
 #define	CB_ENCRYPT_MAGIC	CB_SRC_LABEL	/* Alias, non-overlapping */
 #define	CB_DST_ENDPOINT_ID	CB_SRC_LABEL    /* Alias, non-overlapping */
 #define CB_SRV6_SID_1		CB_SRC_LABEL	/* Alias, non-overlapping */
+#define CB_VERDICT		CB_SRC_LABEL	/* Alias, non-overlapping */
 	CB_1,
 #define	CB_DELIVERY_REDIRECT	CB_1		/* Alias, non-overlapping */
 #define	CB_NAT_46X64		CB_1		/* Alias, non-overlapping */

--- a/bpf/lib/icmp.h
+++ b/bpf/lib/icmp.h
@@ -1,0 +1,166 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include <linux/icmp.h>
+#include <linux/icmpv6.h>
+
+#include "bpf/compiler.h"
+#include "common.h"
+#include "csum.h"
+#include "dbg.h"
+#include "drop.h"
+#include "eth.h"
+#include "overloadable.h"
+
+static __always_inline
+__wsum icmp_wsum_accumulate(void *data_start, void *data_end, int sample_len)
+{
+	/* Unrolled loop to calculate the checksum of the ICMP sample
+	 * Done manually because the compiler refuses with #pragma unroll
+	 */
+	__wsum wsum = 0;
+
+	#define body(i) if ((i) > sample_len) \
+		return wsum; \
+	if (data_start + (i) + sizeof(__u16) > data_end) { \
+		if (data_start + (i) + sizeof(__u8) <= data_end)\
+			wsum += *(__u8 *)(data_start + (i)); \
+		return wsum; \
+	} \
+	wsum += *(__u16 *)(data_start + (i));
+
+	#define body4(i) body(i)\
+		body(i + 2) \
+		body(i + 4) \
+		body(i + 6)
+
+	#define body16(i) body4(i)\
+		body4(i + 8) \
+		body4(i + 16) \
+		body4(i + 24)
+
+	#define body128(i) body16(i)\
+		body16(i + 32) \
+		body16(i + 64) \
+		body16(i + 96)
+
+	body128(0)
+	body128(256)
+	body128(512)
+	body128(768)
+	body128(1024)
+
+	return wsum;
+}
+
+#ifdef ENABLE_IPV4
+
+#define ICMP_PACKET_MAX_SAMPLE_SIZE 64
+
+static __always_inline
+int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code)
+{
+	void *data, *data_end;
+	struct ethhdr *ethhdr;
+	struct iphdr *ip4;
+	struct icmphdr *icmphdr;
+	union macaddr smac = {};
+	union macaddr dmac = {};
+	__be32	saddr;
+	__be32	daddr;
+	__u8	tos;
+	__wsum csum;
+	int sample_len;
+	int ret;
+	const int inner_offset = sizeof(struct ethhdr) + sizeof(struct iphdr) +
+		sizeof(struct icmphdr);
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+	/* copy the incoming src and dest IPs and mac addresses to the stack.
+	 * the pointers will not be valid after adding headroom.
+	 */
+
+	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
+		return DROP_INVALID;
+
+	if (eth_load_daddr(ctx, dmac.addr, 0) < 0)
+		return DROP_INVALID;
+
+	saddr = ip4->saddr;
+	daddr = ip4->daddr;
+	tos = ip4->tos;
+
+	/* Resize to ethernet header + 64 bytes or less */
+	sample_len = (int)ctx_full_len(ctx);
+	if (sample_len > ICMP_PACKET_MAX_SAMPLE_SIZE)
+		sample_len = ICMP_PACKET_MAX_SAMPLE_SIZE;
+	ctx_adjust_troom(ctx, (__s32)(sample_len + sizeof(struct ethhdr) - ctx_full_len(ctx)));
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+
+	/* Calculate the checksum of the ICMP sample */
+	csum = icmp_wsum_accumulate(data + sizeof(struct ethhdr), data_end, sample_len);
+
+	/* We need to insert a IPv4 and ICMP header before the original packet.
+	 * Make that room.
+	 */
+
+#if __ctx_is == __ctx_xdp
+	ret = xdp_adjust_head(ctx, 0 - (int)(sizeof(struct iphdr) + sizeof(struct icmphdr)));
+#else
+	ret = skb_adjust_room(ctx, sizeof(struct iphdr) + sizeof(struct icmphdr),
+			      BPF_ADJ_ROOM_MAC, 0);
+#endif
+
+	if (ret < 0)
+		return DROP_INVALID;
+
+	/* changing size invalidates pointers, so we need to re-fetch them. */
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+
+	/* Bound check all 3 headers at once. */
+	if (data + inner_offset > data_end)
+		return DROP_INVALID;
+
+	/* Write reversed eth header, ready for egress */
+	ethhdr = data;
+	memcpy(ethhdr->h_dest, smac.addr, sizeof(smac.addr));
+	memcpy(ethhdr->h_source, dmac.addr, sizeof(dmac.addr));
+	ethhdr->h_proto = bpf_htons(ETH_P_IP);
+
+	/* Write reversed ip header, ready for egress */
+	ip4 = data + sizeof(struct ethhdr);
+	ip4->version = 4;
+	ip4->ihl = sizeof(struct iphdr) >> 2;
+	ip4->tos = tos;
+	ip4->tot_len = bpf_htons(sizeof(struct iphdr) + sizeof(struct icmphdr) +
+		       (__u16)sample_len);
+	ip4->id = 0;
+	ip4->frag_off = 0;
+	ip4->ttl = IPDEFTTL;
+	ip4->protocol = IPPROTO_ICMP;
+	ip4->check = 0;
+	ip4->daddr = saddr;
+	ip4->saddr = daddr;
+	ip4->check = csum_fold(csum_diff(ip4, 0, ip4, sizeof(struct iphdr), 0));
+
+	/* Write reversed icmp header */
+	icmphdr = data + sizeof(struct ethhdr) + sizeof(struct iphdr);
+	icmphdr->type = icmp_type;
+	icmphdr->code = icmp_code;
+	icmphdr->checksum = 0;
+	icmphdr->un.gateway = 0;
+
+	/* Add ICMP header checksum to sum of its body */
+	csum += csum_diff(icmphdr, 0, icmphdr, sizeof(struct icmphdr), 0);
+	icmphdr->checksum = csum_fold(csum);
+
+	return 0;
+}
+#endif /* ENABLE_IPV4 */

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -14,6 +14,9 @@
 
 #ifndef SKIP_CALLS_MAP
 #include "drop.h"
+#ifdef SERVICE_NO_BACKEND_RESPONSE
+#include "icmp.h"
+#endif
 #endif
 
 #ifdef ENABLE_IPV6
@@ -2027,123 +2030,13 @@ lb4_ctx_restore_state(struct __ctx_buff *ctx, struct ct_state *state,
 #ifndef SKIP_CALLS_MAP
 #ifdef SERVICE_NO_BACKEND_RESPONSE
 
-#define ICMP_PACKET_MAX_SAMPLE_SIZE 64
-
-static __always_inline
-__wsum icmp_wsum_accumulate(void *data_start, void *data_end, int sample_len);
-
-static __always_inline
-int __tail_no_service_ipv4(struct __ctx_buff *ctx)
-{
-	void *data, *data_end;
-	struct ethhdr *ethhdr;
-	struct iphdr *ip4;
-	struct icmphdr *icmphdr;
-	union macaddr smac = {};
-	union macaddr dmac = {};
-	__be32	saddr;
-	__be32	daddr;
-	__u8	tos;
-	__wsum csum;
-	int sample_len;
-	int ret;
-	const int inner_offset = sizeof(struct ethhdr) + sizeof(struct iphdr) +
-		sizeof(struct icmphdr);
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
-
-	/* copy the incoming src and dest IPs and mac addresses to the stack.
-	 * the pointers will not be valid after adding headroom.
-	 */
-
-	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
-		return DROP_INVALID;
-
-	if (eth_load_daddr(ctx, dmac.addr, 0) < 0)
-		return DROP_INVALID;
-
-	saddr = ip4->saddr;
-	daddr = ip4->daddr;
-	tos = ip4->tos;
-
-	/* Resize to ethernet header + 64 bytes or less */
-	sample_len = (int)ctx_full_len(ctx);
-	if (sample_len > ICMP_PACKET_MAX_SAMPLE_SIZE)
-		sample_len = ICMP_PACKET_MAX_SAMPLE_SIZE;
-	ctx_adjust_troom(ctx, (__s32)(sample_len + sizeof(struct ethhdr) - ctx_full_len(ctx)));
-
-	data = ctx_data(ctx);
-	data_end = ctx_data_end(ctx);
-
-	/* Calculate the checksum of the ICMP sample */
-	csum = icmp_wsum_accumulate(data + sizeof(struct ethhdr), data_end, sample_len);
-
-	/* We need to insert a IPv4 and ICMP header before the original packet.
-	 * Make that room.
-	 */
-
-#if __ctx_is == __ctx_xdp
-	ret = xdp_adjust_head(ctx, 0 - (int)(sizeof(struct iphdr) + sizeof(struct icmphdr)));
-#else
-	ret = skb_adjust_room(ctx, sizeof(struct iphdr) + sizeof(struct icmphdr),
-			      BPF_ADJ_ROOM_MAC, 0);
-#endif
-
-	if (ret < 0)
-		return DROP_INVALID;
-
-	/* changing size invalidates pointers, so we need to re-fetch them. */
-	data = ctx_data(ctx);
-	data_end = ctx_data_end(ctx);
-
-	/* Bound check all 3 headers at once. */
-	if (data + inner_offset > data_end)
-		return DROP_INVALID;
-
-	/* Write reversed eth header, ready for egress */
-	ethhdr = data;
-	memcpy(ethhdr->h_dest, smac.addr, sizeof(smac.addr));
-	memcpy(ethhdr->h_source, dmac.addr, sizeof(dmac.addr));
-	ethhdr->h_proto = bpf_htons(ETH_P_IP);
-
-	/* Write reversed ip header, ready for egress */
-	ip4 = data + sizeof(struct ethhdr);
-	ip4->version = 4;
-	ip4->ihl = sizeof(struct iphdr) >> 2;
-	ip4->tos = tos;
-	ip4->tot_len = bpf_htons(sizeof(struct iphdr) + sizeof(struct icmphdr) +
-		       (__u16)sample_len);
-	ip4->id = 0;
-	ip4->frag_off = 0;
-	ip4->ttl = IPDEFTTL;
-	ip4->protocol = IPPROTO_ICMP;
-	ip4->check = 0;
-	ip4->daddr = saddr;
-	ip4->saddr = daddr;
-	ip4->check = csum_fold(csum_diff(ip4, 0, ip4, sizeof(struct iphdr), 0));
-
-	/* Write reversed icmp header */
-	icmphdr = data + sizeof(struct ethhdr) + sizeof(struct iphdr);
-	icmphdr->type = ICMP_DEST_UNREACH;
-	icmphdr->code = ICMP_PORT_UNREACH;
-	icmphdr->checksum = 0;
-	icmphdr->un.gateway = 0;
-
-	/* Add ICMP header checksum to sum of its body */
-	csum += csum_diff(icmphdr, 0, icmphdr, sizeof(struct icmphdr), 0);
-	icmphdr->checksum = csum_fold(csum);
-
-	return 0;
-}
-
 __declare_tail(CILIUM_CALL_IPV4_NO_SERVICE)
 int tail_no_service_ipv4(struct __ctx_buff *ctx)
 {
 	__u32 src_sec_identity = ctx_load_meta(ctx, CB_SRC_LABEL);
 	int ret;
 
-	ret = __tail_no_service_ipv4(ctx);
+	ret = generate_icmp4_reply(ctx, ICMP_DEST_UNREACH, ICMP_PORT_UNREACH);
 	if (!ret) {
 		/* Redirect ICMP to the interface we received it on. */
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
@@ -2341,48 +2234,3 @@ drop_err:
 #endif /* SERVICE_NO_BACKEND_RESPONSE */
 #endif /* SKIP_CALLS_MAP */
 #endif /* ENABLE_IPV6 */
-
-#ifdef SERVICE_NO_BACKEND_RESPONSE
-
-static __always_inline
-__wsum icmp_wsum_accumulate(void *data_start, void *data_end, int sample_len)
-{
-	/* Unrolled loop to calculate the checksum of the ICMP sample
-	 * Done manually because the compiler refuses with #pragma unroll
-	 */
-	__wsum wsum = 0;
-
-	#define body(i) if ((i) > sample_len) \
-		return wsum; \
-	if (data_start + (i) + sizeof(__u16) > data_end) { \
-		if (data_start + (i) + sizeof(__u8) <= data_end)\
-			wsum += *(__u8 *)(data_start + (i)); \
-		return wsum; \
-	} \
-	wsum += *(__u16 *)(data_start + (i));
-
-	#define body4(i) body(i)\
-		body(i + 2) \
-		body(i + 4) \
-		body(i + 6)
-
-	#define body16(i) body4(i)\
-		body4(i + 8) \
-		body4(i + 16) \
-		body4(i + 24)
-
-	#define body128(i) body16(i)\
-		body16(i + 32) \
-		body16(i + 64) \
-		body16(i + 96)
-
-	body128(0)
-	body128(256)
-	body128(512)
-	body128(768)
-	body128(1024)
-
-	return wsum;
-}
-
-#endif /* SERVICE_NO_BACKEND_RESPONSE */

--- a/bpf/lib/tailcall.h
+++ b/bpf/lib/tailcall.h
@@ -97,7 +97,8 @@
 #define CILIUM_CALL_IPV4_NO_SERVICE			45
 #define CILIUM_CALL_IPV6_NO_SERVICE			46
 #define CILIUM_CALL_MULTICAST_EP_DELIVERY		47
-#define CILIUM_CALL_SIZE				48
+#define CILIUM_CALL_IPV4_POLICY_DENIED			48
+#define CILIUM_CALL_SIZE				49
 
 /* Private per-EP map for internal tail calls. Its bpffs pin is replaced every
  * time the BPF object is loaded. An existing pinned map is never reused.

--- a/bpf/tests/tc_nodeport_lb4_no_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_no_backend.c
@@ -169,7 +169,7 @@ int nodeport_no_backend2_reply_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_nodeport_no_backend2_reply")
 int nodeport_no_backend2_reply_setup(struct __ctx_buff *ctx)
 {
-	if (__tail_no_service_ipv4(ctx))
+	if (tail_no_service_ipv4(ctx))
 		return TEST_ERROR;
 
 	/* Jump into the entrypoint */

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -631,6 +631,10 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	option.BindEnv(vp, option.ServiceNoBackendResponse)
 
 	flags.Int(option.TracePayloadlen, defaults.TracePayloadLen, "Length of payload to capture when tracing native packets.")
+
+	flags.String(option.PolicyDenyResponse, defaults.PolicyDenyResponse, "How to handle pod egress traffic dropped by network policy: either drop the packet (\"none\") or reject with an ICMP Destination Unreachable (\"icmp\")")
+	option.BindEnv(vp, option.PolicyDenyResponse)
+
 	option.BindEnv(vp, option.TracePayloadlen)
 
 	flags.Int(option.TracePayloadlenOverlay, defaults.TracePayloadLenOverlay, "Length of payload to capture when tracing overlay packets.")

--- a/pkg/datapath/config/node_config.go
+++ b/pkg/datapath/config/node_config.go
@@ -9,6 +9,8 @@ package config
 // instantiate directly! Always use [NewNode] to ensure the default values
 // configured in the ELF are honored.
 type Node struct {
+	// Enable ICMP responses for policy-denied traffic.
+	PolicyDenyResponseEnabled bool `config:"policy_deny_response_enabled"`
 	// Internal IPv6 router address assigned to the cilium_host interface.
 	RouterIPv6 [16]byte `config:"router_ipv6"`
 	// IPv4 source address used for SNAT when a Pod talks to itself over a Service.
@@ -20,6 +22,6 @@ type Node struct {
 }
 
 func NewNode() *Node {
-	return &Node{[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	return &Node{false, [16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0}, 0x0, 0x0}
 }

--- a/pkg/datapath/loader/config.go
+++ b/pkg/datapath/loader/config.go
@@ -23,5 +23,11 @@ func nodeConfig(lnc *datapath.LocalNodeConfiguration) config.Node {
 	node.TracePayloadLen = uint32(option.Config.TracePayloadlen)
 	node.TracePayloadLenOverlay = uint32(option.Config.TracePayloadlenOverlay)
 
+	if option.Config.PolicyDenyResponse == option.PolicyDenyResponseIcmp {
+		node.PolicyDenyResponseEnabled = true
+	} else {
+		node.PolicyDenyResponseEnabled = false
+	}
+
 	return node
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -505,6 +505,9 @@ const (
 	// Use the CiliumInternalIPs (vs. NodeInternalIPs) for IPsec encapsulation.
 	UseCiliumInternalIPForIPsec = false
 
+	// PolicyDenyResponse is the default action for pod egress network policy denials (drop packets silently)
+	PolicyDenyResponse = "none"
+
 	// TunnelPortVXLAN is the default VXLAN port
 	TunnelPortVXLAN uint16 = 8472
 	// TunnelPortGeneve is the default Geneve port

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -478,6 +478,15 @@ const (
 	// without any backends
 	ServiceNoBackendResponseDrop = "drop"
 
+	// PolicyDenyResponse is the name of the option to pick how to handle ipv4 egress traffic denied by policy
+	PolicyDenyResponse = "policy-deny-response"
+
+	// PolicyDenyResponseIcmp is the name of the option to reject traffic denied by policy with an ICMP response
+	PolicyDenyResponseIcmp = "icmp"
+
+	// PolicyDenyResponseNone is the name of the option to silently drop traffic denied by policy
+	PolicyDenyResponseNone = "none"
+
 	// MaxInternalTimerDelay sets a maximum on all periodic timers in
 	// the agent in order to flush out timer-related bugs in the agent.
 	MaxInternalTimerDelay = "max-internal-timer-delay"
@@ -1993,6 +2002,9 @@ type DaemonConfig struct {
 	// ServiceNoBackendResponse determines how we handle traffic to a service with no backends.
 	ServiceNoBackendResponse string
 
+	// PolicyDenyResponse determines how we handle pod egress traffic denied by network policy.
+	PolicyDenyResponse string
+
 	// EnableNodeSelectorLabels enables use of the node label based identity
 	EnableNodeSelectorLabels bool
 
@@ -2739,6 +2751,14 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	}
 
 	c.populateLoadBalancerSettings(logger, vp)
+	c.PolicyDenyResponse = vp.GetString(PolicyDenyResponse)
+	switch c.PolicyDenyResponse {
+	case PolicyDenyResponseIcmp, PolicyDenyResponseNone:
+	case "":
+		c.PolicyDenyResponse = defaults.PolicyDenyResponse
+	default:
+		logging.Fatal(logger, "Invalid value for --%s: %s (must be 'icmp' or 'none')", PolicyDenyResponse, c.PolicyDenyResponse)
+	}
 	c.EgressMultiHomeIPRuleCompat = vp.GetBool(EgressMultiHomeIPRuleCompat)
 	c.InstallUplinkRoutesForDelegatedIPAM = vp.GetBool(InstallUplinkRoutesForDelegatedIPAM)
 


### PR DESCRIPTION
Backport `--policy-deny-response=icmp` feature from PR 41406