### PR TITLE
azure: emit Azure API rate-limit metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -904,6 +904,19 @@ Name                                     Labels                                 
 ``ipam_needed_ips``                      ``target_node``                                                   Enabled    Number of IPs needed to satisfy allocation on a node.
 ======================================== ================================================================= ========== ========================================================
 
+The following metrics are emitted by the Azure IPAM allocator and report the
+remaining Azure API request budget extracted from response headers. See
+`Azure Resource Manager throttling
+<https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling#remaining-requests>`__
+for the meaning of each header.
+
+========================================== ================================================================= ========== ========================================================
+Name                                       Labels                                                            Default    Description
+========================================== ================================================================= ========== ========================================================
+``azure_ratelimit_remaining``              ``description``, ``subscription_id``                              Enabled    Remaining Azure API rate-limit budget reported by ``X-Ms-Ratelimit-Remaining-*`` response headers.
+``azure_ratelimit_remaining_resource``     ``policy``, ``subscription_id``                                   Enabled    Remaining Azure API rate-limit budget per resource policy reported by ``X-Ms-Ratelimit-Remaining-Resource`` response header.
+========================================== ================================================================= ========== ========================================================
+
 LB-IPAM
 ~~~~~~~
 

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
@@ -67,6 +68,8 @@ type Client struct {
 type MetricsAPI interface {
 	ObserveAPICall(call, status string, duration float64)
 	ObserveRateLimit(operation string, duration time.Duration)
+	ObserveRateLimitRemaining(description, subscriptionID string, value float64)
+	ObserveRateLimitRemainingResource(policyName, subscriptionID string, value float64)
 }
 
 // net/http Client with a custom cilium user agent
@@ -89,9 +92,10 @@ func newTokenCredential(clientOptions *azcore.ClientOptions, userAssignedIdentit
 	})
 }
 
-func newClientOptions(cloudName string) (*azcore.ClientOptions, error) {
+func newClientOptions(cloudName string, perRetry policy.Policy) (*azcore.ClientOptions, error) {
 	clientOptions := &azcore.ClientOptions{
-		Transport: &httpClient{},
+		Transport:        &httpClient{},
+		PerRetryPolicies: []policy.Policy{perRetry},
 	}
 
 	// See possible values here:
@@ -114,7 +118,7 @@ func newClientOptions(cloudName string) (*azcore.ClientOptions, error) {
 
 // NewClient returns a new Azure client
 func NewClient(logger *slog.Logger, cloudName, subscriptionID, resourceGroup, userAssignedIdentityID string, metrics MetricsAPI, rateLimit float64, burst int, usePrimary bool) (*Client, error) {
-	clientOptions, err := newClientOptions(cloudName)
+	clientOptions, err := newClientOptions(cloudName, newRateLimitMetricsExtractor(logger, subscriptionID, metrics))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/azure/api/ratelimit_metrics.go
+++ b/pkg/azure/api/ratelimit_metrics.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const (
+	rateLimitMetricHeaderPrefix      = "X-Ms-Ratelimit-Remaining-"
+	rateLimitRemainingResourceHeader = "X-Ms-Ratelimit-Remaining-Resource"
+)
+
+// rateLimitMetricsObserver is the subset of MetricsAPI used to record Azure
+// API rate-limit budget headers. It mirrors what *Metrics in
+// pkg/ipam/allocator/azure provides without creating an import cycle.
+type rateLimitMetricsObserver interface {
+	ObserveRateLimitRemaining(description, subscriptionID string, value float64)
+	ObserveRateLimitRemainingResource(policy, subscriptionID string, value float64)
+}
+
+// rateLimitMetricsExtractor is a per-retry pipeline policy that records
+// Azure API rate-limit response headers as Prometheus metrics.
+//
+// See https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling#remaining-requests
+type rateLimitMetricsExtractor struct {
+	logger         *slog.Logger
+	subscriptionID string
+	metrics        rateLimitMetricsObserver
+}
+
+var _ policy.Policy = (*rateLimitMetricsExtractor)(nil)
+
+func newRateLimitMetricsExtractor(logger *slog.Logger, subscriptionID string, metrics rateLimitMetricsObserver) *rateLimitMetricsExtractor {
+	return &rateLimitMetricsExtractor{
+		logger:         logger,
+		subscriptionID: subscriptionID,
+		metrics:        metrics,
+	}
+}
+
+// Do forwards the request, then on a non-error response extracts rate-limit
+// headers into metrics. Malformed header values are logged and skipped, other
+// headers in the same response are still recorded.
+func (e *rateLimitMetricsExtractor) Do(req *policy.Request) (*http.Response, error) {
+	resp, err := req.Next()
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	e.extract(resp)
+	return resp, nil
+}
+
+func (e *rateLimitMetricsExtractor) extract(resp *http.Response) {
+	logger := e.logger
+	if resp.Request != nil && resp.Request.URL != nil {
+		logger = logger.With(
+			logfields.URL, resp.Request.URL.String(),
+			logfields.Status, resp.Status,
+			logfields.Method, resp.Request.Method,
+		)
+	}
+
+	for headerKey, headerValues := range resp.Header {
+		if len(headerValues) == 0 {
+			continue
+		}
+		headerValue := headerValues[0]
+		switch {
+		case headerKey == rateLimitRemainingResourceHeader:
+			e.extractResource(logger, headerValue)
+		case strings.HasPrefix(headerKey, rateLimitMetricHeaderPrefix):
+			description := strings.ToLower(strings.TrimPrefix(headerKey, rateLimitMetricHeaderPrefix))
+			e.extractRemaining(logger, description, headerValue)
+		}
+	}
+}
+
+func (e *rateLimitMetricsExtractor) extractRemaining(logger *slog.Logger, description, headerValue string) {
+	value, err := strconv.ParseInt(headerValue, 10, 64)
+	if err != nil {
+		logger.Warn("Failed to parse Azure rate-limit remaining header value, skipping",
+			logfields.Error, err,
+			logfields.Description, description,
+			logfields.Value, headerValue,
+		)
+		return
+	}
+
+	subscriptionID, ok := e.subscriptionIDForDescription(description)
+	if !ok {
+		logger.Warn("Unknown Azure rate-limit description, skipping",
+			logfields.Description, description,
+		)
+		return
+	}
+
+	e.metrics.ObserveRateLimitRemaining(description, subscriptionID, float64(value))
+}
+
+// extractResource parses the X-Ms-Ratelimit-Remaining-Resource header, whose
+// value is a comma-separated list of policy;count pairs. Malformed segments
+// are logged and skipped, valid segments in the same value are still recorded.
+func (e *rateLimitMetricsExtractor) extractResource(logger *slog.Logger, headerValue string) {
+	if headerValue == "" {
+		return
+	}
+	for segment := range strings.SplitSeq(headerValue, ",") {
+		policyName, countStr, ok := strings.Cut(segment, ";")
+		if !ok {
+			logger.Warn("Failed to parse Azure rate-limit resource header segment, skipping",
+				logfields.Segment, segment,
+				logfields.Value, headerValue,
+			)
+			continue
+		}
+		value, err := strconv.ParseInt(countStr, 10, 64)
+		if err != nil {
+			logger.Warn("Failed to parse Azure rate-limit resource header count, skipping",
+				logfields.Error, err,
+				logfields.Policy, policyName,
+				logfields.Count, countStr,
+			)
+			continue
+		}
+		e.metrics.ObserveRateLimitRemainingResource(policyName, e.subscriptionID, float64(value))
+	}
+}
+
+// subscriptionIDForDescription decides which subscription_id label value to
+// use for a given description. Tenant-scoped descriptions get an empty value
+// because the budget is shared across the tenant rather than per subscription.
+// Returns false if the description is not in a recognized scope.
+func (e *rateLimitMetricsExtractor) subscriptionIDForDescription(description string) (string, bool) {
+	switch {
+	case strings.HasPrefix(description, "subscription-"):
+		return e.subscriptionID, true
+	case strings.HasPrefix(description, "tenant-"):
+		return "", true
+	default:
+		return "", false
+	}
+}

--- a/pkg/azure/api/ratelimit_metrics_test.go
+++ b/pkg/azure/api/ratelimit_metrics_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+)
+
+type observation struct {
+	description    string
+	subscriptionID string
+	value          float64
+}
+
+type resourceObservation struct {
+	policy         string
+	subscriptionID string
+	value          float64
+}
+
+type fakeObserver struct {
+	remaining []observation
+	resource  []resourceObservation
+}
+
+func (f *fakeObserver) ObserveRateLimitRemaining(description, subscriptionID string, value float64) {
+	f.remaining = append(f.remaining, observation{description, subscriptionID, value})
+}
+
+func (f *fakeObserver) ObserveRateLimitRemainingResource(policyName, subscriptionID string, value float64) {
+	f.resource = append(f.resource, resourceObservation{policyName, subscriptionID, value})
+}
+
+func newExtractor(t *testing.T, obs *fakeObserver) *rateLimitMetricsExtractor {
+	t.Helper()
+	return newRateLimitMetricsExtractor(hivetest.Logger(t), "sub-1", obs)
+}
+
+func newResponse(headers http.Header) *http.Response {
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+		Header:     headers,
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    &url.URL{Scheme: "https", Host: "example.test", Path: "/"},
+		},
+	}
+}
+
+func TestExtract_Remaining_SubscriptionScoped(t *testing.T) {
+	obs := &fakeObserver{}
+	headers := http.Header{}
+	headers.Set("X-Ms-Ratelimit-Remaining-Subscription-Reads", "11999")
+	headers.Set("X-Ms-Ratelimit-Remaining-Subscription-Writes", "1199")
+
+	newExtractor(t, obs).extract(newResponse(headers))
+
+	require.ElementsMatch(t, []observation{
+		{"subscription-reads", "sub-1", 11999},
+		{"subscription-writes", "sub-1", 1199},
+	}, obs.remaining)
+	require.Empty(t, obs.resource)
+}
+
+func TestExtract_Remaining_TenantScopedHasEmptySubscriptionID(t *testing.T) {
+	obs := &fakeObserver{}
+	headers := http.Header{}
+	headers.Set("X-Ms-Ratelimit-Remaining-Tenant-Reads", "11999")
+	headers.Set("X-Ms-Ratelimit-Remaining-Tenant-Writes", "1199")
+
+	newExtractor(t, obs).extract(newResponse(headers))
+
+	require.ElementsMatch(t, []observation{
+		{"tenant-reads", "", 11999},
+		{"tenant-writes", "", 1199},
+	}, obs.remaining)
+}
+
+func TestExtract_Remaining_UnknownDescriptionSkipped(t *testing.T) {
+	obs := &fakeObserver{}
+	headers := http.Header{}
+	headers.Set("X-Ms-Ratelimit-Remaining-Mystery-Scope", "42")
+	// A valid header alongside the unknown one must still be recorded.
+	headers.Set("X-Ms-Ratelimit-Remaining-Subscription-Reads", "5")
+
+	newExtractor(t, obs).extract(newResponse(headers))
+
+	require.Equal(t, []observation{{"subscription-reads", "sub-1", 5}}, obs.remaining)
+	require.Empty(t, obs.resource)
+}
+
+func TestExtract_Remaining_MalformedIntegerSkipped(t *testing.T) {
+	obs := &fakeObserver{}
+	headers := http.Header{}
+	headers.Set("X-Ms-Ratelimit-Remaining-Subscription-Reads", "not-a-number")
+	// A valid header alongside the malformed one must still be recorded.
+	headers.Set("X-Ms-Ratelimit-Remaining-Subscription-Writes", "7")
+
+	newExtractor(t, obs).extract(newResponse(headers))
+
+	require.Equal(t, []observation{{"subscription-writes", "sub-1", 7}}, obs.remaining)
+}
+
+func TestExtract_Resource_MultipleSegments(t *testing.T) {
+	obs := &fakeObserver{}
+	headers := http.Header{}
+	headers.Set("X-Ms-Ratelimit-Remaining-Resource", "Microsoft.Compute/HighCostGet3Min;107,Microsoft.Compute/HighCostGet30Min;547")
+
+	newExtractor(t, obs).extract(newResponse(headers))
+
+	require.Equal(t, []resourceObservation{
+		{"Microsoft.Compute/HighCostGet3Min", "sub-1", 107},
+		{"Microsoft.Compute/HighCostGet30Min", "sub-1", 547},
+	}, obs.resource)
+}
+
+func TestExtract_Resource_EmptyValue(t *testing.T) {
+	obs := &fakeObserver{}
+	headers := http.Header{}
+	headers.Set("X-Ms-Ratelimit-Remaining-Resource", "")
+
+	newExtractor(t, obs).extract(newResponse(headers))
+
+	require.Empty(t, obs.resource)
+}
+
+func TestExtract_Resource_MalformedSegmentSkipped(t *testing.T) {
+	obs := &fakeObserver{}
+	headers := http.Header{}
+	// Second segment has no ';' separator, extraction must skip just that
+	// segment and still record the surrounding valid ones.
+	headers.Set("X-Ms-Ratelimit-Remaining-Resource", "Microsoft.Compute/HighCostGet3Min;107,broken-segment,Microsoft.Compute/HighCostGet30Min;547")
+
+	newExtractor(t, obs).extract(newResponse(headers))
+
+	require.Equal(t, []resourceObservation{
+		{"Microsoft.Compute/HighCostGet3Min", "sub-1", 107},
+		{"Microsoft.Compute/HighCostGet30Min", "sub-1", 547},
+	}, obs.resource)
+}
+
+func TestExtract_Resource_MalformedCountSkipped(t *testing.T) {
+	obs := &fakeObserver{}
+	headers := http.Header{}
+	headers.Set("X-Ms-Ratelimit-Remaining-Resource", "Microsoft.Compute/HighCostGet3Min;not-a-number,Microsoft.Compute/HighCostGet30Min;547")
+
+	newExtractor(t, obs).extract(newResponse(headers))
+
+	require.Equal(t, []resourceObservation{
+		{"Microsoft.Compute/HighCostGet30Min", "sub-1", 547},
+	}, obs.resource)
+}
+
+func TestExtract_IgnoresUnrelatedHeaders(t *testing.T) {
+	obs := &fakeObserver{}
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+	headers.Set("X-Ms-Request-Id", "abc")
+	headers.Set("X-Ms-Ratelimit-Remaining-Subscription-Reads", "5")
+
+	newExtractor(t, obs).extract(newResponse(headers))
+
+	require.Equal(t, []observation{{"subscription-reads", "sub-1", 5}}, obs.remaining)
+	require.Empty(t, obs.resource)
+}
+
+func TestSubscriptionIDForDescription(t *testing.T) {
+	e := newRateLimitMetricsExtractor(hivetest.Logger(t), "sub-42", &fakeObserver{})
+
+	tests := []struct {
+		description string
+		wantID      string
+		wantOK      bool
+	}{
+		{"subscription-reads", "sub-42", true},
+		{"subscription-writes", "sub-42", true},
+		{"tenant-reads", "", true},
+		{"tenant-writes", "", true},
+		{"mystery-scope", "", false},
+		{"", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			got, ok := e.subscriptionIDForDescription(tc.description)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.wantID, got)
+		})
+	}
+}

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
-	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
 	azureAPI "github.com/cilium/cilium/pkg/azure/api"
 	azureIPAM "github.com/cilium/cilium/pkg/azure/ipam"
 	"github.com/cilium/cilium/pkg/ipam"
@@ -71,10 +70,10 @@ func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNod
 	}
 
 	if operatorOption.Config.EnableMetrics {
-		azMetrics = apiMetrics.NewPrometheusMetrics(metrics.Namespace, "azure", reg)
+		azMetrics = NewMetrics(reg)
 		iMetrics = ipamMetrics.NewPrometheusMetrics(metrics.Namespace, reg)
 	} else {
-		azMetrics = &apiMetrics.NoOpMetrics{}
+		azMetrics = &NoOpMetrics{}
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
 

--- a/pkg/ipam/allocator/azure/metrics.go
+++ b/pkg/ipam/allocator/azure/metrics.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package azure
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const (
+	labelDescription    = "description"
+	labelSubscriptionID = "subscription_id"
+	labelPolicy         = "policy"
+)
+
+// Metrics holds the metrics for the Azure API client. It embeds the shared
+// PrometheusMetrics (APIDuration, RateLimit) and adds the Azure-specific
+// rate-limit-remaining gauges.
+type Metrics struct {
+	*apiMetrics.PrometheusMetrics
+
+	// RateLimitRemaining tracks the X-Ms-Ratelimit-Remaining-* response
+	// headers. subscription_id is empty for tenant-scoped descriptions
+	// because the budget is shared across the tenant rather than per
+	// subscription.
+	// See https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling#remaining-requests
+	RateLimitRemaining *prometheus.GaugeVec
+
+	// RateLimitRemainingResource tracks the X-Ms-Ratelimit-Remaining-Resource
+	// response header.
+	// See https://learn.microsoft.com/en-us/azure/virtual-machines/troubleshooting/troubleshooting-throttling-errors#call-rate-informational-response-headers
+	RateLimitRemainingResource *prometheus.GaugeVec
+}
+
+// NewMetrics returns the metrics for the Azure API client.
+func NewMetrics(registry *metrics.Registry) *Metrics {
+	rateLimitRemaining := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.CiliumOperatorNamespace,
+		Subsystem: "azure",
+		Name:      "ratelimit_remaining",
+		Help:      "Remaining Azure API rate-limit budget reported by the X-Ms-Ratelimit-Remaining-* response headers",
+	}, []string{labelDescription, labelSubscriptionID})
+
+	rateLimitRemainingResource := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.CiliumOperatorNamespace,
+		Subsystem: "azure",
+		Name:      "ratelimit_remaining_resource",
+		Help:      "Remaining Azure API rate-limit budget per resource policy reported by the X-Ms-Ratelimit-Remaining-Resource response header",
+	}, []string{labelPolicy, labelSubscriptionID})
+
+	registry.MustRegister(rateLimitRemaining)
+	registry.MustRegister(rateLimitRemainingResource)
+
+	return &Metrics{
+		PrometheusMetrics:          apiMetrics.NewPrometheusMetrics(metrics.Namespace, "azure", registry),
+		RateLimitRemaining:         rateLimitRemaining,
+		RateLimitRemainingResource: rateLimitRemainingResource,
+	}
+}
+
+// ObserveRateLimitRemaining records the remaining rate-limit budget for the
+// given description. subscriptionID must be empty for tenant-scoped
+// descriptions.
+func (m *Metrics) ObserveRateLimitRemaining(description, subscriptionID string, value float64) {
+	m.RateLimitRemaining.WithLabelValues(description, subscriptionID).Set(value)
+}
+
+// ObserveRateLimitRemainingResource records the remaining rate-limit budget
+// for the given Azure policy.
+func (m *Metrics) ObserveRateLimitRemainingResource(policyName, subscriptionID string, value float64) {
+	m.RateLimitRemainingResource.WithLabelValues(policyName, subscriptionID).Set(value)
+}
+
+// NoOpMetrics is a no-op implementation of the Azure MetricsAPI interface.
+type NoOpMetrics struct {
+	apiMetrics.NoOpMetrics
+}
+
+// ObserveRateLimitRemaining is a no-op.
+func (m *NoOpMetrics) ObserveRateLimitRemaining(description, subscriptionID string, value float64) {
+}
+
+// ObserveRateLimitRemainingResource is a no-op.
+func (m *NoOpMetrics) ObserveRateLimitRemainingResource(policyName, subscriptionID string, value float64) {
+}
+
+// ensure Metrics & NoOpMetrics implement the API client's MetricsAPI surface.
+var _ interface {
+	ObserveAPICall(call, status string, duration float64)
+	ObserveRateLimit(operation string, duration time.Duration)
+	ObserveRateLimitRemaining(description, subscriptionID string, value float64)
+	ObserveRateLimitRemainingResource(policyName, subscriptionID string, value float64)
+} = (*Metrics)(nil)
+
+var _ interface {
+	ObserveAPICall(call, status string, duration float64)
+	ObserveRateLimit(operation string, duration time.Duration)
+	ObserveRateLimitRemaining(description, subscriptionID string, value float64)
+	ObserveRateLimitRemainingResource(policyName, subscriptionID string, value float64)
+} = (*NoOpMetrics)(nil)

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1865,4 +1865,10 @@ const (
 	AttachType = "attachType"
 
 	WithFrags = "withFrags"
+
+	Description = "description"
+
+	Segment = "segment"
+
+	Policy = "policy"
 )


### PR DESCRIPTION
Azure API responses include X-Ms-Ratelimit-Remaining-* headers that report how much of the request budget is left for the subscription or tenant scope. Surfacing these as Prometheus metrics lets operators see how close they are to throttling before requests start failing.

Add a per-retry pipeline policy (rateLimitMetricsExtractor) that runs inside the azcore client pipeline. On each response it parses the remaining-budget headers and records two new gauges on the existing Azure IPAM allocator Metrics struct:

* `cilium_operator_azure_ratelimit_remaining{description, subscription_id}`
* `cilium_operator_azure_ratelimit_remaining_resource{policy, subscription_id}`

subscription_id is left empty for tenant-scoped descriptions (tenant-reads, tenant-writes, ...) since the budget is shared across the tenant and labeling it with one subscription would be misleading.